### PR TITLE
PACE-56/Add side bar and payment summary in cart page

### DIFF
--- a/public/icons/btn_setting.svg
+++ b/public/icons/btn_setting.svg
@@ -1,0 +1,19 @@
+<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_732_791)">
+<circle cx="22" cy="22" r="20" fill="white"/>
+<path d="M22 25C23.6569 25 25 23.6569 25 22C25 20.3431 23.6569 19 22 19C20.3431 19 19 20.3431 19 22C19 23.6569 20.3431 25 22 25Z" stroke="#666666" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 22.8804V21.1204C12 20.0804 12.85 19.2204 13.9 19.2204C15.71 19.2204 16.45 17.9404 15.54 16.3704C15.02 15.4704 15.33 14.3004 16.24 13.7804L17.97 12.7904C18.76 12.3204 19.78 12.6004 20.25 13.3904L20.36 13.5804C21.26 15.1504 22.74 15.1504 23.65 13.5804L23.76 13.3904C24.23 12.6004 25.25 12.3204 26.04 12.7904L27.77 13.7804C28.68 14.3004 28.99 15.4704 28.47 16.3704C27.56 17.9404 28.3 19.2204 30.11 19.2204C31.15 19.2204 32.01 20.0704 32.01 21.1204V22.8804C32.01 23.9204 31.16 24.7804 30.11 24.7804C28.3 24.7804 27.56 26.0604 28.47 27.6304C28.99 28.5404 28.68 29.7004 27.77 30.2204L26.04 31.2104C25.25 31.6804 24.23 31.4004 23.76 30.6104L23.65 30.4204C22.75 28.8504 21.27 28.8504 20.36 30.4204L20.25 30.6104C19.78 31.4004 18.76 31.6804 17.97 31.2104L16.24 30.2204C15.33 29.7004 15.02 28.5304 15.54 27.6304C16.45 26.0604 15.71 24.7804 13.9 24.7804C12.85 24.7804 12 23.9204 12 22.8804Z" stroke="#666666" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_d_732_791" x="0" y="0" width="48" height="48" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.05 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_732_791"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_732_791" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,9 +1,19 @@
 import Sidebar from '@/components/my-page-side-bar';
+import CartList from '@/components/cart-list';
+import PaymentSummary from '@/components/payment-summary';
 
 export default function CartPage() {
   return (
     <div className="w-screen grid grid-cols-[320px_1fr_320px] min-h-screen">
       <Sidebar />
+
+      <main className="flex-1 p-[40px] pt-[80px]">
+        <CartList />
+      </main>
+
+      <aside className="border-l p-[40px] pt-[80px]">
+        <PaymentSummary />
+      </aside>
     </div>
   );
 }

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -1,8 +1,9 @@
-export default function PlaceholderPage() {
+import Sidebar from '@/components/my-page-side-bar';
+
+export default function CartPage() {
   return (
-    <div className="p-4 text-gray-500">
-      <h1 className="text-lg font-semibold">🚧 Page Under Construction</h1>
-      <p>This page is currently being set up.</p>
+    <div className="w-screen grid grid-cols-[320px_1fr_320px] min-h-screen">
+      <Sidebar />
     </div>
   );
 }

--- a/src/components/cart-list.tsx
+++ b/src/components/cart-list.tsx
@@ -1,0 +1,7 @@
+export default function CartList() {
+  return (
+    <section>
+      <h2 className="text-xl font-semibold mb-4">장바구니</h2>
+    </section>
+  );
+}

--- a/src/components/my-page-side-bar.tsx
+++ b/src/components/my-page-side-bar.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import profileImg from '../../public/img/resume_lecture.jpeg';
+
+const menuItems = [
+  { label: '마이페이지', href: '/mypage' },
+  { label: '장바구니', href: '/cart' },
+  { label: '찜목록', href: '/mypage/favorites' },
+  { label: '구매 내역', href: '/mypage/purchases' },
+  { label: '1:1문의', href: '/mypage/inquiries' },
+  { label: '로그아웃', href: '/logout' }
+];
+
+export default function Sidebar() {
+  return (
+    <aside className="hidden md:flex flex-col w-80 h-screen shrink-0 border-r bg-white py-8">
+      <div className="relative flex flex-col items-center mb-8">
+        <Image
+          src={profileImg}
+          alt="프로필"
+          className="w-40 h-40 rounded-full mb-4"
+          width={160}
+          height={160}
+        />
+        <button
+          type="button"
+          className="absolute -top-5 right-3"
+          aria-label="환경설정"
+        >
+          <Image
+            src="/icons/btn_setting.svg"
+            alt="로그인 아이콘"
+            width={40}
+            height={40}
+            className="hover:opacity-75"
+          />
+        </button>
+
+        <h2 className="text-pace-xl text-pace-gray-500 font-semibold">Jamie</h2>
+      </div>
+
+      <nav className="flex flex-col">
+        {menuItems.map((item, index) => {
+          const isLast = index === menuItems.length - 1;
+          const borderClasses = `${isLast ? 'border-b' : ''}`;
+
+          return (
+            <Link
+              key={item.label}
+              href={item.href}
+              className={`flex items-center justify-center text-pace-stone-500 hover:bg-pace-ivory-500 hover:font-medium hover:text-pace-gray-700 py-6 border-t ${borderClasses}`}
+            >
+              <span>{item.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/components/payment-summary.tsx
+++ b/src/components/payment-summary.tsx
@@ -1,0 +1,40 @@
+export default function PaymentSummary() {
+  return (
+    <aside>
+      <h2 className="text-pace-lg text-pace-gray-700 font-bold mb-4">
+        예상 결제 금액
+      </h2>
+      <ul className="text-pace-base text-pace-gray-700 space-y-4 mb-6 pb-[24px] border-b border-pace-gray-700">
+        <li className="flex justify-between">
+          <span className="text-[#6B7280]">소계 (3개의 강의)</span>
+          <span>$264.97</span>
+        </li>
+        <li className="flex justify-between">
+          <span className="text-[#6B7280]">할인 금액</span>
+          <span>-$20.00</span>
+        </li>
+        <li className="flex justify-between">
+          <span className="text-[#6B7280]">세금</span>
+          <span>$24.49</span>
+        </li>
+      </ul>
+      <div className="flex justify-between items-center font-semibold text-pace-lg mb-6">
+        <span className="text-pace-gray-700">총 결제 금액</span>
+        <span className="font-bold text-[#E86642]">$260.46</span>
+      </div>
+      <div className="flex h-[30px] gap-1 mb-6 text-pace-sm">
+        <input
+          type="text"
+          placeholder="프로모션 코드 입력"
+          className="flex-grow px-3 py-1 placeholder-[#757575] rounded-full border border-[#EEEEEE]"
+        />
+        <button className="px-3 py-1 text-pace-gray-700 rounded-full border border-[#EEEEEE]">
+          등록
+        </button>
+      </div>
+      <button className="w-full bg-pace-orange-800 hover:bg-orange-600 text-white font-bold py-3 rounded-full">
+        결제하기
+      </button>
+    </aside>
+  );
+}


### PR DESCRIPTION
## Why this PR:
Add side bar and payment summary in cart page

## Changes:
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/c22d8389-1c86-4aed-bac7-b6d6e2f4560e" />

## How to Test:
- Run `npm run dev` and go to `/cart`
- Check if the sidebar is displayed properly and navigates to other pages
- Check if the payment summary is displayed properly