### PR TITLE
PACE-82/Add UserRole Table, Remove Role enum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5805,10 +5805,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -6765,9 +6766,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9044,9 +9045,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/prisma/migrations/20250614005454_add_user_role_table_remove_role_enum/migration.sql
+++ b/prisma/migrations/20250614005454_add_user_role_table_remove_role_enum/migration.sql
@@ -1,0 +1,39 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `role` on the `User` table. All the data in the column will be lost.
+
+*/
+-- =======================
+-- ROLE ENUM → TABLE 전환
+-- =======================
+-- STEP 1: UserRole 테이블 생성
+CREATE TABLE "UserRole" (
+  "id" TEXT PRIMARY KEY,
+  "label" TEXT NOT NULL
+);
+
+-- STEP 2: Role 데이터 삽입
+INSERT INTO "UserRole" ("id", "label") VALUES
+('USER', '일반 사용자'),
+('ADMIN', '관리자'),
+('INSTRUCTOR', '강사');
+
+-- STEP 3: roleId 임시로 추가
+ALTER TABLE "User" ADD COLUMN "roleId" TEXT;
+
+-- STEP 4: enum → 텍스트로 복사
+UPDATE "User" SET "roleId" = "role"::TEXT;
+
+-- STEP 5: role 컬럼 제거 
+ALTER TABLE "User" DROP COLUMN "role";
+
+-- STEP 6: enum 타입 제거
+DROP TYPE IF EXISTS "Role";
+
+-- STEP 7: FK 제약 추가
+ALTER TABLE "User"
+ALTER COLUMN "roleId" SET NOT NULL;
+
+ALTER TABLE "User"
+ADD CONSTRAINT "User_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "UserRole"("id") ON DELETE RESTRICT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,8 @@ model User {
   email     String   @unique
   name      String?
   image     String?
-  role      Role     @default(USER)
+  roleId    String   @default("USER")
+  role      UserRole @relation(fields: [roleId], references: [id]) //* 추가됨
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
@@ -35,6 +36,12 @@ model User {
   workshopRegistrations WorkshopRegistration[] // 사용자가 등록한 워크숍
 
   favorites             Favorite[]
+}
+
+model UserRole { 
+  id    String @id
+  label String
+  users User[]
 }
 
 model Video {
@@ -171,12 +178,6 @@ model Favorite {
   @@unique([userId, videoId])
   @@unique([userId, documentId])
   @@unique([userId, workshopId])
-}
-
-enum Role {
-  USER
-  ADMIN
-  INSTRUCTOR
 }
 
 enum WorkshopStatus {

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -33,13 +33,13 @@ export async function PATCH(req: Request) {
     }
 
     const body = await req.json();
-    const { name, role } = body;
+    const { name, roleId } = body;
 
     const updatedUser = await prisma.user.update({
       where: { clerkId: userId },
       data: {
         ...(name && { name }),
-        ...(role && { role }),
+        ...(roleId && { roleId }),
         updatedAt: new Date()
       }
     });

--- a/src/app/context-test/page.tsx
+++ b/src/app/context-test/page.tsx
@@ -10,7 +10,7 @@ export default function UserContextTestPage() {
   const { isLoaded, isSignedIn } = useUser();
   const { user, isLoading, error, setUser } = useUserContext();
   const [nameInput, setNameInput] = useState('');
-  const [roleInput, setRoleInput] = useState('');
+  const [roleIdInput, setRoleIdInput] = useState('');
 
   const fetchUserInfo = useCallback(async () => {
     try {
@@ -48,7 +48,7 @@ export default function UserContextTestPage() {
         ? {
             ...prev,
             name: nameInput || prev.name,
-            role: roleInput || prev.role,
+            roleId: roleIdInput || prev.roleId,
             updatedAt: new Date().toISOString()
           }
         : null
@@ -65,7 +65,7 @@ export default function UserContextTestPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: nameInput || user.name,
-          role: roleInput || user.role
+          roleId: roleIdInput || user.roleId
         })
       });
 
@@ -109,7 +109,7 @@ export default function UserContextTestPage() {
         <div className="mb-4">
           <p>이름: {user.name ?? 'N/A'}</p>
           <p>이메일: {user.email}</p>
-          <p>역할: {user.role}</p>
+          <p>역할: {user.roleId}</p>
           <p>Clerk ID: {user.clerkId}</p>
         </div>
       ) : (
@@ -127,8 +127,8 @@ export default function UserContextTestPage() {
         <input
           type="text"
           placeholder="역할 입력"
-          value={roleInput}
-          onChange={(e) => setRoleInput(e.target.value)}
+          value={roleIdInput}
+          onChange={(e) => setRoleIdInput(e.target.value)}
           className="border px-2 py-1 rounded w-full"
         />
         <div className="flex flex-col sm:flex-row gap-2">

--- a/src/app/context/user-context.tsx
+++ b/src/app/context/user-context.tsx
@@ -20,7 +20,7 @@ import { User } from '@/types/user';
  *    {
  *      name: 'Seulgi',
  *      email: 'seulgi-dev@gmail.com',
- *      role: 'ADMIN',
+ *      roleId: 'ADMIN',
  *      clerkId: 'user_xxxxx'
  *    }
  *  추가) set 함수, api 호출 re-fatch

--- a/src/components/admin-page.tsx
+++ b/src/components/admin-page.tsx
@@ -18,7 +18,7 @@ export default function AdminPage({ children }: { children: React.ReactNode }) {
       return router.push('/');
     }
 
-    if (user && user.role !== 'ADMIN') {
+    if (user && user.roleId !== 'ADMIN') {
       toast('Access denied');
       return router.push('/');
     }
@@ -26,7 +26,7 @@ export default function AdminPage({ children }: { children: React.ReactNode }) {
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <p>Error: {error}</p>;
-  if (!user || user.role !== 'ADMIN') return null;
+  if (!user || user.roleId !== 'ADMIN') return null;
 
   return (
     <>

--- a/src/components/user-info.tsx
+++ b/src/components/user-info.tsx
@@ -84,7 +84,7 @@ const UserInfo = () => {
         <h3>User Info (from DB)</h3>
         <p>Name: {userInfo.name || 'N/A'}</p>
         <p>Email: {userInfo.email}</p>
-        <p>Role: {userInfo.role}</p>
+        <p>RoleId: {userInfo.roleId}</p>
         <p>ClerkId: {userInfo.clerkId}</p>
       </div>
     );

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -4,7 +4,7 @@ export interface User {
   email: string;
   name: string | null;
   image: string | null;
-  role: string;
+  roleId: string;
   isSubscribed: boolean;
   subscriptionEndDate: string | null;
   createdAt: string;


### PR DESCRIPTION
## Why this PR:
To improve schema flexibility and scalability, the enum-based Role system has been replaced with a table-based structure.

## Changes:
Removed the Role enum and introduced a new Role table

Updated the User model: replaced role with roleId as a foreign key referencing the Role table

Fully updated schema.prisma to reflect new relation definitions and constraints

## How to Test:
0. Make sure your .env file points to your local Docker database instance

1. Run the following command to update your local PostgreSQL schema:
`npx prisma migrate dev`

2. Using pgAdmin or another database tool, confirm the following:
  The Role table has been created  
  The User table includes a roleId field with a proper foreign key constraint

3. Check all pages that are relevant to User Role.