### PR TITLE
fix-homepage-card-carousel-left-side

### DIFF
--- a/public/icons/circle-arrow-left.svg
+++ b/public/icons/circle-arrow-left.svg
@@ -1,0 +1,18 @@
+<svg width="68" height="68" viewBox="0 0 68 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2310_154)">
+<circle cx="28" cy="28" r="28" transform="matrix(-1 0 0 1 60 4)" fill="white"/>
+<path d="M35.512 38.7886L29.9235 33.2C29.2635 32.54 29.2635 31.46 29.9235 30.8L35.512 25.2114" stroke="#888888" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_d_2310_154" x="0" y="0" width="68" height="68" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2310_154"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2310_154" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/icons/circle-arrow-right.svg
+++ b/public/icons/circle-arrow-right.svg
@@ -1,0 +1,18 @@
+<svg width="68" height="68" viewBox="0 0 68 68" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_2310_148)">
+<circle cx="28" cy="28" r="28" transform="matrix(-1 0 0 1 60 4)" fill="white"/>
+<path d="M29.4286 38.7886L35.0172 33.2C35.6772 32.54 35.6772 31.46 35.0172 30.8L29.4286 25.2114" stroke="#888888" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<filter id="filter0_d_2310_148" x="0" y="0" width="68" height="68" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="3"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_2310_148"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_2310_148" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/__tests__/card-container.test.tsx
+++ b/src/components/__tests__/card-container.test.tsx
@@ -1,8 +1,13 @@
 // src/components/__tests__/CardContainer.test.tsx
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { OnlineCards } from '@/types/online';
 import CardContainer from '../common/card-container';
+
+// scrollTo 메서드를 전역적으로 모킹
+beforeEach(() => {
+  Element.prototype.scrollTo = vi.fn();
+});
 
 // Mock the Card component
 vi.mock('../common/card', () => ({
@@ -63,7 +68,7 @@ describe('CardContainer', () => {
     // 다음 버튼이 보여야 함 (ChevronRight 아이콘을 포함한 버튼)
     const nextButton = screen.getByRole('button', { name: /next/i });
     expect(nextButton).toBeInTheDocument();
-    expect(nextButton).toHaveClass('md:right-[calc(100%-1210px)]');
+    expect(nextButton).toHaveClass('right-[360px]');
   });
 
   it('shows/hides navigation buttons based on current index', () => {
@@ -85,16 +90,11 @@ describe('CardContainer', () => {
   });
 
   it('handles navigation button clicks correctly', () => {
-    const { container } = render(
+    render(
       <CardContainer layout="horizontal" cards={mockCards} />
     );
 
     const nextButton = screen.getByRole('button', { name: /next/i });
-    const scrollContainer = container.querySelector('.flex.overflow-hidden');
-
-    if (scrollContainer) {
-      scrollContainer.scrollTo = vi.fn();
-    }
 
     fireEvent.click(nextButton);
 
@@ -102,7 +102,9 @@ describe('CardContainer', () => {
     expect(
       screen.getByRole('button', { name: /previous/i })
     ).toBeInTheDocument();
-    expect(scrollContainer?.scrollTo).toHaveBeenCalled();
+    
+    // scrollTo가 호출되었는지 확인
+    expect(Element.prototype.scrollTo).toHaveBeenCalled();
   });
 
   it('renders empty container when no cards provided', () => {

--- a/src/components/common/card-container.tsx
+++ b/src/components/common/card-container.tsx
@@ -19,15 +19,31 @@ export default function CardContainer({
 }: CardContainerProps) {
   const [currentIndex, setCurrentIndex] = React.useState(0);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const didInitRef = React.useRef(false);
   const cardWidth = 588; // Card 컴포넌트의 width 값
-  const gap = 16; // gap-4 = 16px
+  const gap = 24; // gap-6 = 24px
 
+  // 초기 위치: 첫 번째 카드가 절반만 보이도록 (왼쪽 빈 카드 고려)
+  React.useEffect(() => {
+    if (didInitRef.current) return;
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = cardWidth + gap - cardWidth / 2;
+      didInitRef.current = true;
+    }
+  }, [cardWidth, gap]);
+
+  const PlaceholderCard = () => (
+    <div className="flex-none bg-transparent">
+      <div className="w-[652px] bg-transparent rounded-lg shadow-sm border-transparent border"></div>
+    </div>
+  );
   const handlePrev = () => {
     if (currentIndex > 0) {
-      setCurrentIndex(currentIndex - 1);
+      const nextIndex = currentIndex - 1;
+      setCurrentIndex(nextIndex);
       if (containerRef.current) {
         containerRef.current.scrollTo({
-          left: (currentIndex - 1) * (cardWidth + gap),
+          left: (nextIndex + 1) * (cardWidth + gap) - cardWidth / 2,
           behavior: 'smooth'
         });
       }
@@ -36,10 +52,11 @@ export default function CardContainer({
 
   const handleNext = () => {
     if (currentIndex < cards.length - 1) {
-      setCurrentIndex(currentIndex + 1);
+      const nextIndex = currentIndex + 1;
+      setCurrentIndex(nextIndex);
       if (containerRef.current) {
         containerRef.current.scrollTo({
-          left: (currentIndex + 1) * (cardWidth + gap),
+          left: (nextIndex + 1) * (cardWidth + gap) - cardWidth / 2,
           behavior: 'smooth'
         });
       }
@@ -68,47 +85,59 @@ export default function CardContainer({
       </div>
     );
   }
+  // 왼쪽 화살표: 첫 번째 카드가 완전히 보일 때부터 표시
+  const showLeftButton = currentIndex > 0;
+  // 오른쪽 화살표: 마지막 카드가 중앙 2개 카드 영역의 2번째 위치에 완전히 보일 때까지 표시
+  const showRightButton = currentIndex < cards.length - 2;
 
   return (
-    <div className="relative w-full">
-      {currentIndex > 0 && (
+    <div className="relative w-screen">
+      {showLeftButton && (
         <Button
           variant="outline"
           size="icon"
-          className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
+          className="absolute left-[360px] top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
           onClick={handlePrev}
           aria-label="previous"
         >
           <ChevronLeft className="h-6 w-6" />
         </Button>
       )}
-      <div
-        ref={containerRef}
-        className="flex gap-6 pb-4 w-[calc(100vw-360px)] overflow-hidden min-w-[1200px]"
-      >
-        {cards.map((card) => (
-          <div key={card.id} className="flex-none">
-            <Card
-              id={card.id}
-              title={card.title}
-              price={card.price}
-              description={card.description}
-              category={card.category}
-              itemId={card.itemId}
-              uploadDate={card.uploadDate}
-              watchedVideos={card.watchedVideos}
-              purchasedVideos={card.purchasedVideos}
-              itemType={itemType}
-              thumbnail={card.thumbnail}
-            />
-          </div>
-        ))}
+
+      <div ref={containerRef} className="overflow-hidden">
+        <div className="flex gap-6 pb-4">
+          {/* 왼쪽 빈 카드 - 항상 존재 */}
+          <PlaceholderCard />
+
+          {/* 실제 카드들 */}
+          {cards.map((card) => (
+            <div key={card.id} className="flex-none">
+              <Card
+                id={card.id}
+                title={card.title}
+                price={card.price}
+                description={card.description}
+                category={card.category}
+                itemId={card.itemId}
+                uploadDate={card.uploadDate}
+                watchedVideos={card.watchedVideos}
+                purchasedVideos={card.purchasedVideos}
+                itemType={itemType}
+                thumbnail={card.thumbnail}
+              />
+            </div>
+          ))}
+
+          {/* 오른쪽 빈 카드 - 항상 존재 */}
+          <PlaceholderCard />
+        </div>
       </div>
-      {currentIndex < cards.length - 2 && (
+
+      {showRightButton && (
         <Button
           variant="outline"
           size="icon"
-          className="absolute md:right-[calc(100%-1210px)] top-1/2 -translate-y-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
+          className="absolute right-[360px] top-1/2 -translate-y-1/2 translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
           onClick={handleNext}
           aria-label="next"
         >

--- a/src/components/image-overlay-card-container.tsx
+++ b/src/components/image-overlay-card-container.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { OnlineCards } from '@/types/online';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import ImageOverlayCard from './image-overlay-card';
+import { Button } from './ui/button';
 
 interface ImageOverlayCardContainerProps {
   layout: 'grid' | 'horizontal';
@@ -15,15 +16,34 @@ export default function ImageOverlayCardContainer({
 }: ImageOverlayCardContainerProps) {
   const [currentIndex, setCurrentIndex] = React.useState(0);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const cardWidth = 588; // Card 컴포넌트의 width 값
+  const didInitRef = React.useRef(false);
+  const cardWidth = 384; // Card 컴포넌트의 width 값
   const gap = 16; // gap-4 = 16px
+
+  React.useEffect(() => {
+    if (didInitRef.current) return;
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = 50 + 0 * (cardWidth + gap);
+      didInitRef.current = true;
+    }
+  }, [cardWidth, gap]);
+
+  const PlaceholderCard = () => (
+    <div className="flex-none bg-transparent">
+      <div className="w-[384px] bg-transparent rounded-lg shadow-sm border-transparent border"></div>
+    </div>
+  );
 
   const handlePrev = () => {
     if (currentIndex > 0) {
-      setCurrentIndex(currentIndex - 1);
+      const nextIndex = currentIndex - 1;
+      setCurrentIndex(nextIndex);
       if (containerRef.current) {
+        const isFirstClick = currentIndex === 1;
+        const scrollPosition =
+          50 + nextIndex * (cardWidth + gap) + (isFirstClick ? 5 : 10);
         containerRef.current.scrollTo({
-          left: (currentIndex - 1) * (cardWidth + gap),
+          left: scrollPosition,
           behavior: 'smooth'
         });
       }
@@ -32,10 +52,16 @@ export default function ImageOverlayCardContainer({
 
   const handleNext = () => {
     if (currentIndex < cards.length - 1) {
-      setCurrentIndex(currentIndex + 1);
+      const nextIndex = currentIndex + 1;
+      setCurrentIndex(nextIndex);
       if (containerRef.current) {
+        const isFirstClick = currentIndex === 0;
+        const scrollPosition =
+          50 +
+          nextIndex * (cardWidth + gap) +
+          (isFirstClick ? 5 : 10 * currentIndex);
         containerRef.current.scrollTo({
-          left: (currentIndex + 1) * (cardWidth + gap),
+          left: scrollPosition,
           behavior: 'smooth'
         });
       }
@@ -68,47 +94,58 @@ export default function ImageOverlayCardContainer({
     );
   }
 
+  // 왼쪽 화살표: 첫 번째 카드가 완전히 보일 때부터 표시
+  const showLeftButton = currentIndex > 0;
+  // 오른쪽 화살표: 마지막 카드가 중앙 3개 카드 영역의 3번째 위치에 완전히 보일 때까지 표시
+  const showRightButton = currentIndex < cards.length - 3;
+
   return (
-    <div className="relative w-full" data-testid="horizontal-container">
-      {currentIndex > 0 && (
-        <button
+    <div className="relative w-screen" data-testid="horizontal-container">
+      {showLeftButton && (
+        <Button
           aria-label="previous"
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input hover:text-accent-foreground absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
+          className="absolute left-[360px] top-1/2 -translate-y-1/2 -translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
           onClick={handlePrev}
         >
           <ChevronLeft className="h-6 w-6" />
-        </button>
+        </Button>
       )}
-      <div
-        ref={containerRef}
-        className="flex gap-6 pb-4 w-[calc(100vw-360px)] overflow-hidden min-w-[1200px]"
-      >
-        {cards.map((card) => (
-          <div key={card.id} className="flex-none">
-            <ImageOverlayCard
-              id={card.id}
-              title={card.title}
-              price={card.price}
-              description={card.description}
-              category={card.category}
-              itemId={card.itemId}
-              uploadDate={card.uploadDate}
-              watchedVideos={card.watchedVideos}
-              purchasedVideos={card.purchasedVideos}
-              thumbnail={card.thumbnail}
-            />
-          </div>
-        ))}
+      <div ref={containerRef} className="overflow-hidden">
+        <div className="flex gap-6 pb-4">
+          {/* 왼쪽 빈 카드 - 항상 존재 */}
+          <PlaceholderCard />
+
+          {/* 실제 카드들 */}
+          {cards.map((card) => (
+            <div key={card.id} className="flex-none">
+              <ImageOverlayCard
+                id={card.id}
+                title={card.title}
+                price={card.price}
+                description={card.description}
+                category={card.category}
+                itemId={card.itemId}
+                uploadDate={card.uploadDate}
+                watchedVideos={card.watchedVideos}
+                purchasedVideos={card.purchasedVideos}
+                thumbnail={card.thumbnail}
+              />
+            </div>
+          ))}
+
+          {/* 오른쪽 빈 카드 - 항상 존재 */}
+          <PlaceholderCard />
+        </div>
+        {showRightButton && (
+          <Button
+            aria-label="next"
+            className="absolute right-[360px] top-1/2 -translate-y-1/2 translate-x-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
+            onClick={handleNext}
+          >
+            <ChevronRight className="h-6 w-6" />
+          </Button>
+        )}
       </div>
-      {currentIndex < cards.length - 2 && (
-        <button
-          aria-label="next"
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 border border-input hover:text-accent-foreground absolute right-[calc(100%-1210px)] top-1/2 -translate-y-1/2 z-10 bg-white rounded-full shadow-md hover:bg-gray-100 w-14 h-14"
-          onClick={handleNext}
-        >
-          <ChevronRight className="h-6 w-6" />
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/image-overlay-card.tsx
+++ b/src/components/image-overlay-card.tsx
@@ -27,7 +27,7 @@ export default function ImageOverlayCard({
   return (
     <div className="cursor-pointer" data-testid="image-overlay-card">
       <Link href={`/courses/${itemId}`}>
-        <div className="w-[354px] bg-white rounded-lg hover:shadow-xl dark:bg-gray-950 relative overflow-hidden group">
+        <div className="w-[384px] bg-white rounded-lg hover:shadow-xl dark:bg-gray-950 relative overflow-hidden group">
           <button
             role="button"
             aria-label="like"


### PR DESCRIPTION
## Why this PR:
- fix homepage card carousel left side card

## Changes:
- Modify the CSS and calculation of the card container
- Modify CSS and calculations for image overlay card containers

## How to Test:
- `npm run dev`
- On the main screen, check if the online lecture/e-book cards are displayed properly in 1/2 - 2 - 1/2 on the full screen when you press the arrow to turn the cards
- On the main screen, check if the workshop cards are displayed properly in 1/3 - 3 - 1/3 on the full screen when you press the arrow to turn the cards