### PR TITLE
[PACE-240] workshop card routing bug

### DIFF
--- a/src/components/image-overlay-card.tsx
+++ b/src/components/image-overlay-card.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useState, useMemo } from 'react';
 
 export default function ImageOverlayCard({
-  itemId,
+  id,
   title,
   visualTitle2,
   category,
@@ -58,7 +58,7 @@ export default function ImageOverlayCard({
 
   return (
     <div className="cursor-pointer" data-testid="image-overlay-card">
-      <Link href={`/courses/${itemId}`}>
+      <Link href={`/workshops/${id}`}>
         <div className="w-[384px] bg-white rounded-lg dark:bg-gray-950 relative overflow-hidden group transition-transform duration-300 hover:scale-105">
           <button
             role="button"


### PR DESCRIPTION
## Why this PR:
- fix workshop card routing bug


AS-IS
/courses/undefined

TO-BE
/workshops/{workshopId}

## Changes:
- `<Link href={`/courses/${itemId}`}>` -> `<Link href={`/workshops/${id}`}>`

## How to Test:
- go to main page -> click workshop card

<img width="900" height="387" alt="Screenshot 2026-04-12 at 12 22 09 PM" src="https://github.com/user-attachments/assets/48e7ff43-81c2-4675-94ba-30bd54d04017" />
