### PR TITLE
chore: revert @next/env to 15.5.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@headlessui/react": "^2.2.9",
         "@hookform/resolvers": "^5.2.2",
+        "@next/env": "^15.5.15",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -55,7 +56,7 @@
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.3",
         "@eslint/eslintrc": "^3.3.5",
-        "@next/env": "^16.2.4",
+        "@next/env": "^15.5.15",
         "@next/eslint-plugin-next": "^15.5.6",
         "@storybook/addon-designs": "^10.0.2",
         "@storybook/addon-docs": "^9.1.13",
@@ -3424,10 +3425,9 @@
       "license": "MIT"
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
-      "dev": true,
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -12951,12 +12951,6 @@
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
-    },
-    "node_modules/next/node_modules/@next/env": {
-      "version": "15.5.15",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
-      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
-      "license": "MIT"
     },
     "node_modules/next/node_modules/@swc/helpers": {
       "version": "0.5.15",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@headlessui/react": "^2.2.9",
     "@hookform/resolvers": "^5.2.2",
-    "@next/env": "^16.2.4",
+    "@next/env": "^15.5.15",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "@radix-ui/react-checkbox": "^1.3.3",
@@ -69,7 +69,7 @@
   "devDependencies": {
     "@chromatic-com/storybook": "^4.1.3",
     "@eslint/eslintrc": "^3.3.5",
-    "@next/env": "^16.2.4",
+    "@next/env": "^15.5.15",
     "@next/eslint-plugin-next": "^15.5.6",
     "@storybook/addon-designs": "^10.0.2",
     "@storybook/addon-docs": "^9.1.13",


### PR DESCRIPTION
## Summary
- Revert Dependabot PR #863's @next/env 16.2.4 bump
- Keep @next/env aligned with Next.js 15.5.15 in dependencies and devDependencies

## Validation
- npm ci
- npm run prisma:generate
- npm test -- --run
- npm run build