### PR TITLE
chore: harden dependency update automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,254 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      aws-sdk-s3:
+        patterns:
+          - '@aws-sdk/client-s3'
+          - '@aws-sdk/s3-request-presigner'
+        update-types:
+          - 'minor'
+          - 'patch'
+      react-runtime:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+        update-types:
+          - 'minor'
+          - 'patch'
+      next-framework:
+        patterns:
+          - 'next'
+          - '@next/env'
+          - 'eslint-config-next'
+          - '@next/eslint-plugin-next'
+        update-types:
+          - 'minor'
+          - 'patch'
+      clerk-auth:
+        patterns:
+          - '@clerk/backend'
+          - '@clerk/nextjs'
+        update-types:
+          - 'minor'
+          - 'patch'
+      prisma:
+        patterns:
+          - 'prisma'
+          - '@prisma/client'
+          - '@prisma/adapter-pg'
+          - 'pg'
+        update-types:
+          - 'minor'
+          - 'patch'
+      pdf-viewer:
+        patterns:
+          - 'react-pdf'
+          - 'pdfjs-dist'
+        update-types:
+          - 'minor'
+          - 'patch'
+      filepond:
+        patterns:
+          - 'react-filepond'
+          - 'filepond'
+          - 'filepond-plugin-image-preview'
+        update-types:
+          - 'minor'
+          - 'patch'
+      dnd-kit:
+        patterns:
+          - '@dnd-kit/core'
+          - '@dnd-kit/sortable'
+          - '@dnd-kit/utilities'
+        update-types:
+          - 'minor'
+          - 'patch'
+      form-validation:
+        patterns:
+          - 'react-hook-form'
+          - '@hookform/resolvers'
+          - 'zod'
+        update-types:
+          - 'minor'
+          - 'patch'
+      storybook:
+        patterns:
+          - 'storybook'
+          - '@storybook/*'
+          - 'eslint-plugin-storybook'
+          - '@chromatic-com/storybook'
+        update-types:
+          - 'minor'
+          - 'patch'
+      vite-test-tooling:
+        patterns:
+          - 'vitest'
+          - 'vite'
+          - '@vitejs/plugin-react'
+          - 'vite-tsconfig-paths'
+          - 'happy-dom'
+          - 'jsdom'
+        update-types:
+          - 'minor'
+          - 'patch'
+      tailwind-tooling:
+        patterns:
+          - 'tailwindcss'
+          - 'tailwind-merge'
+          - 'postcss'
+          - 'autoprefixer'
+        update-types:
+          - 'minor'
+          - 'patch'
+      typescript-eslint:
+        patterns:
+          - '@typescript-eslint/eslint-plugin'
+          - '@typescript-eslint/parser'
+        update-types:
+          - 'minor'
+          - 'patch'
+    ignore:
+      - dependency-name: '@aws-sdk/client-s3'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@aws-sdk/s3-request-presigner'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@types/react'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@types/react-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'next'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@next/env'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint-config-next'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@next/eslint-plugin-next'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@clerk/backend'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@clerk/nextjs'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'prisma'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@prisma/client'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@prisma/adapter-pg'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'pg'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-pdf'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'pdfjs-dist'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-filepond'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'filepond'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'filepond-plugin-image-preview'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@dnd-kit/core'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@dnd-kit/sortable'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@dnd-kit/utilities'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-hook-form'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@hookform/resolvers'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'zod'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'storybook'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@storybook/*'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint-plugin-storybook'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@chromatic-com/storybook'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'tailwindcss'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@typescript-eslint/eslint-plugin'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@typescript-eslint/parser'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'vitest'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'vite'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: '@vitejs/plugin-react'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'vite-tsconfig-paths'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'happy-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'jsdom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-day-picker'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'tailwind-merge'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'postcss'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'autoprefixer'
+        update-types:
+          - 'version-update:semver-major'
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: 'github-actions'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12963,9 +12963,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12982,9 +12982,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -111,6 +111,9 @@
     "@hono/node-server": "1.19.14",
     "@prisma/dev": "0.24.3",
     "effect": "^3.21.0",
+    "next": {
+      "postcss": "8.5.14"
+    },
     "node-polyfill-webpack-plugin": "^4.1.0"
   },
   "lint-staged": {


### PR DESCRIPTION
## Why this PR:

Dependabot was creating separate PRs for dependency sets that should move together, and risky semver-major updates could still be opened automatically. `npm install` also reported 5 moderate vulnerabilities from Next's nested PostCSS dependency.

## Changes:

- Add Dependabot npm groups for version-coupled dependency sets such as React, Next, Clerk, Prisma, Storybook, Vite/Vitest, Tailwind, FilePond, PDF, and dnd-kit.
- Ignore Dependabot semver-major version PRs for dependencies that need planned migration work.
- Override Next's nested `postcss` dependency to `8.5.14` and update the lockfile so npm audit resolves to zero vulnerabilities.

## How to Test:

- `ruby -e "require 'yaml'; YAML.load_file('.github/dependabot.yml'); puts 'yaml ok'"`
- `npx prettier --check .github/dependabot.yml`
- `npm install`
- `npm audit --json | jq '.metadata.vulnerabilities'`
- `npm run typecheck`