### PR TITLE
fix: add Clerk SSO callback route

### DIFF
--- a/src/app/sso-callback/page.tsx
+++ b/src/app/sso-callback/page.tsx
@@ -1,0 +1,13 @@
+import { AuthenticateWithRedirectCallback } from '@clerk/nextjs';
+
+export default function SSOCallbackPage() {
+  return (
+    <>
+      <AuthenticateWithRedirectCallback
+        signInFallbackRedirectUrl="/"
+        signUpFallbackRedirectUrl="/"
+      />
+      <div id="clerk-captcha" />
+    </>
+  );
+}


### PR DESCRIPTION
## Why this PR:
- Google OAuth redirects to /sso-callback during the Clerk custom OAuth flow.
- The app did not have an /sso-callback route, so production users could end up stuck on that page instead of completing auth and returning home.

## Changes:
- Add /sso-callback route using Clerk's AuthenticateWithRedirectCallback.
- Set sign-in/sign-up fallback redirect URLs to /.
- Include Clerk captcha mount node for sign-up flows.

## How to Test:
- npm run typecheck
- On this branch or Vercel Preview, verify `/sso-callback` returns 200.
- Complete Google OAuth sign-up/sign-in against the preview/local environment and confirm the final redirect lands on `/`.
- After merge and production deploy, verify `https://www.paceupcareer.com/sso-callback` returns 200.

## Follow-up:
- The `Invalid video ID format` toast on `/sso-callback` is unrelated to this callback route. It is caused by the global PurchaseProvider treating the first URL segment as a video ID and should be handled separately.
