### PR TITLE
chore: raise Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     pull-request-branch-name:
       separator: '-'
     directory: '/'
+    open-pull-requests-limit: 20
     schedule:
       interval: 'weekly'
     groups:
@@ -261,5 +262,6 @@ updates:
     pull-request-branch-name:
       separator: '-'
     directory: '/.github/workflows'
+    open-pull-requests-limit: 20
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
## Summary
- raise the Dependabot open PR limit for npm updates from the default 5 to 20
- raise the GitHub Actions Dependabot open PR limit to 20 as well

## Validation
- npx prettier --check .github/dependabot.yml
- git diff --check
- pre-commit hook passed: prisma generate, branch-name validation, typecheck, lint-staged
