### PR TITLE
[PACE-221] Apply list order index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "date-fns": "^4.4.0",
         "embla-carousel-react": "^8.6.0",
         "filepond-plugin-image-preview": "^4.6.12",
+        "fractional-indexing": "^3.2.0",
         "lucide-react": "^1.17.0",
         "next": "15.5.19",
         "next-themes": "^0.4.6",
@@ -9608,6 +9609,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fractional-indexing": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz",
+      "integrity": "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "date-fns": "^4.4.0",
     "embla-carousel-react": "^8.6.0",
     "filepond-plugin-image-preview": "^4.6.12",
+    "fractional-indexing": "^3.2.0",
     "lucide-react": "^1.17.0",
     "next": "15.5.19",
     "next-themes": "^0.4.6",

--- a/prisma/migrations/20260521012558_add_ebook_order_index/migration.sql
+++ b/prisma/migrations/20260521012558_add_ebook_order_index/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "Ebook" RENAME CONSTRAINT "Document_pkey" TO "Ebook_pkey";
+
+-- AlterTable
+ALTER TABLE "Ebook" ADD COLUMN "orderIndex" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "Video" ALTER COLUMN "courseId" DROP NOT NULL;
+
+-- RenameIndex
+ALTER INDEX "Document_documentId_key" RENAME TO "Ebook_ebookId_key";

--- a/prisma/migrations/20260525000000_ebook_fractional_ordering/migration.sql
+++ b/prisma/migrations/20260525000000_ebook_fractional_ordering/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: replace orderIndex with orderKey
+ALTER TABLE "Ebook" DROP COLUMN "orderIndex";
+ALTER TABLE "Ebook" ADD COLUMN "orderKey" TEXT NOT NULL DEFAULT 'a0';

--- a/prisma/migrations/20260528000000_add_order_key_to_courses_workshops/migration.sql
+++ b/prisma/migrations/20260528000000_add_order_key_to_courses_workshops/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Course" ADD COLUMN "orderKey" TEXT NOT NULL DEFAULT 'a0';
+
+-- AlterTable
+ALTER TABLE "Workshop" ADD COLUMN "orderKey" TEXT NOT NULL DEFAULT 'a0';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Course {
   visualTitle         String?
   visualTitle2        String?
   recommendedLinks    Json?
+  orderKey            String               @default("a0")
   instructors         Instructor[]
   videos              Video[]              @relation("CourseToVideos")
   sectionsRel         Section[]
@@ -154,6 +155,7 @@ model Ebook {
   visualTitle2        String?
   recommendedLinks    Json?
   targetAudienceTypes TargetAudienceType[] @default([])
+  orderKey            String               @default("a0")
 }
 
 model Workshop {
@@ -171,6 +173,7 @@ model Workshop {
   category       WorkshopCategory?
   processContent String?
   isMain         Boolean           @default(false)
+  orderKey       String            @default("a0")
 
   // 강사: 한 워크샵에 여러 강사, 한 강사가 여러 워크샵 가능 (다대다)
   instructors   WorkshopInstructor[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -8,6 +8,7 @@ import {
   TargetAudienceType,
   WorkshopStatus
 } from '@prisma/client';
+import { generateNKeysBetween } from 'fractional-indexing';
 import { PrismaPg } from '@prisma/adapter-pg';
 import { randomUUID } from 'crypto';
 
@@ -249,6 +250,8 @@ async function main() {
     }
   });
 
+  const courseOrderKeys = generateNKeysBetween(null, null, 6);
+
   console.log('Generating English e-books...');
   const courseIds = Array.from({ length: 6 }, () => randomUUID());
 
@@ -269,6 +272,7 @@ async function main() {
         category: categoryString as CourseCategory,
         isPublic: true,
         showOnMain: true,
+        orderKey: courseOrderKeys[i - 1],
         title: `${TITLE} - Volume ${i}`,
         description: DESCRIPTION,
         processTitle: PROCESS_TITLE,
@@ -347,6 +351,7 @@ async function main() {
   }
 
   console.log('Generating English e-books...');
+  const ebookOrderKeys = generateNKeysBetween(null, null, 6);
   const ebooks = [
     {
       category: EbookCategory.MARKETING,
@@ -452,6 +457,7 @@ async function main() {
         isPublic: true,
         subTitle: ebook.subTitle,
         isMain: i < 4,
+        orderKey: ebookOrderKeys[i],
         visualTitle1: ebook.visualTitle1,
         visualTitle2: ebook.visualTitle2,
         tableOfContents: ebookToc,
@@ -586,6 +592,8 @@ async function main() {
   }
 
   console.log('Generating dummy workshops...');
+  const workshopOrderKeys = generateNKeysBetween(null, null, 8);
+  let workshopOrderIdx = 0;
   const uxDesignWorkshopData = [
     {
       title: 'UX Design Workshop',
@@ -637,6 +645,7 @@ async function main() {
         status,
         category: ws.category as WorkshopCategory,
         thumbnail: '/img/course_image1.png',
+        orderKey: workshopOrderKeys[workshopOrderIdx++],
         instructors: {
           create: [{ instructorId: instructorId2 }]
         }
@@ -705,6 +714,7 @@ async function main() {
         status,
         category: ws.category as WorkshopCategory,
         thumbnail: ws.thumbnail,
+        orderKey: workshopOrderKeys[workshopOrderIdx++],
         instructors: {
           create: [{ instructorId: instructorId2 }]
         }

--- a/src/app/admin/courses/page.tsx
+++ b/src/app/admin/courses/page.tsx
@@ -26,20 +26,22 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useNavigationBlocker } from '@/components/admin/common/navigation-blocker-context';
+import { generateKeyBetween } from 'fractional-indexing';
 
 const CATEGORY_LABELS = itemCategoryLabel.en;
 
 type Row = {
   id: string;
-  title: string; // 강의제목
-  description: string; // 강의내용
-  price: string; // 금액
-  likes: number; // 찜
-  purchases: number; // 구매
+  title: string;
+  description: string;
+  price: string;
+  likes: number;
+  purchases: number;
   status: '공개중' | '비공개' | string;
   thumbnail: string;
-  selected: boolean; // 선택 여부 필드 추가
-  category: string; // 카테고리 필드 추가 (Enum 키값)
+  selected: boolean;
+  category: string;
+  orderKey: string;
 };
 
 // Sortable Row
@@ -326,34 +328,38 @@ export default function Page() {
 
   const handleSave = async () => {
     try {
+      const orderUpdates = rows.map((r) => ({
+        id: r.id,
+        orderKey: r.orderKey
+      }));
       const selectedRows = rows.filter((row) => row.selected);
 
-      if (selectedRows.length === 0) {
-        toast.info('저장할 항목을 선택해주세요.');
-        return;
+      const promises: Promise<unknown>[] = [
+        fetch('/api/courses/reorder', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: orderUpdates })
+        })
+      ];
+
+      if (selectedRows.length > 0) {
+        const updates = selectedRows.map((row) => ({
+          id: row.id,
+          status: row.status
+        }));
+        promises.push(
+          fetch('/api/courses', {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ updates })
+          })
+        );
       }
 
-      const updates = selectedRows.map((row) => ({
-        id: row.id,
-        status: row.status
-      }));
-
-      const res = await fetch('/api/courses', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({ updates })
-      });
-
-      if (res.ok) {
-        toast.success('저장되었습니다.');
-        await fetchCourses();
-        setBlocked(false); // 저장 완료 시 변경상태 해제
-      } else {
-        const errorData = await res.json();
-        toast.error(`저장 실패: ${errorData.error || 'Unknown error'}`);
-      }
+      await Promise.all(promises);
+      toast.success('저장되었습니다.');
+      await fetchCourses();
+      setBlocked(false);
     } catch {
       toast.error('저장 중 오류가 발생했습니다.');
     }
@@ -361,12 +367,20 @@ export default function Page() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (over && active.id !== over.id) {
-      const oldIndex = rows.findIndex((row) => row.id === active.id);
-      const newIndex = rows.findIndex((row) => row.id === over.id);
-      setRows((items) => arrayMove(items, oldIndex, newIndex));
-      setBlocked(true);
-    }
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = rows.findIndex((row) => row.id === active.id);
+    const newIndex = rows.findIndex((row) => row.id === over.id);
+    const newRows = arrayMove(rows, oldIndex, newIndex);
+
+    const before = newRows[newIndex - 1]?.orderKey ?? null;
+    const after = newRows[newIndex + 1]?.orderKey ?? null;
+    const newKey = generateKeyBetween(before, after);
+
+    setRows(
+      newRows.map((r) => (r.id === active.id ? { ...r, orderKey: newKey } : r))
+    );
+    setBlocked(true);
   };
 
   // 카테고리별로 필터링된 rows

--- a/src/app/admin/ebooks/page.tsx
+++ b/src/app/admin/ebooks/page.tsx
@@ -9,6 +9,7 @@ import {
   updateEbookStatuses,
   EbookWithStats
 } from '@/components/admin/ebooks/actions/ebook-actions';
+import { generateKeyBetween } from 'fractional-indexing';
 import { Checkbox } from '@/components/ui/checkbox';
 import PaceSelect from '@/components/ui/admin/select';
 import { itemCategoryLabel } from '@/constants/labels';
@@ -42,6 +43,7 @@ type Row = {
   thumbnail: string;
   selected: boolean;
   category: string;
+  orderKey: string;
 };
 // Sortable Row Component
 function VisualRow({
@@ -229,7 +231,8 @@ export default function AdminEbooksPage() {
           purchaseCount: doc.purchaseCount || 0,
           likes: doc.likes || 0,
           status: doc.isPublic ? '공개중' : '비공개',
-          selected: false
+          selected: false,
+          orderKey: doc.orderKey
         }));
         setRows(mappedRows);
       } catch {
@@ -246,16 +249,24 @@ export default function AdminEbooksPage() {
   }, [currentPage, fetchData]);
 
   const handleSave = async () => {
-    // Identify modified statuses
-    const updates = rows.map((r) => ({
+    const statusUpdates = rows.map((r) => ({
       id: r.id,
       isPublic: r.status === '공개중'
     }));
 
+    const orderUpdates = rows.map((r) => ({ id: r.id, orderKey: r.orderKey }));
+
     try {
-      await updateEbookStatuses(updates);
+      await Promise.all([
+        updateEbookStatuses(statusUpdates),
+        fetch('/api/ebooks/reorder', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: orderUpdates })
+        })
+      ]);
       alert('저장되었습니다.');
-      fetchData(currentPage); // Refresh
+      fetchData(currentPage);
     } catch {
       alert('저장에 실패했습니다.');
     }
@@ -305,11 +316,19 @@ export default function AdminEbooksPage() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (over && active.id !== over.id) {
-      const oldIndex = rows.findIndex((row) => row.id === active.id);
-      const newIndex = rows.findIndex((row) => row.id === over.id);
-      setRows((items) => arrayMove(items, oldIndex, newIndex));
-    }
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = rows.findIndex((row) => row.id === active.id);
+    const newIndex = rows.findIndex((row) => row.id === over.id);
+    const newRows = arrayMove(rows, oldIndex, newIndex);
+
+    const before = newRows[newIndex - 1]?.orderKey ?? null;
+    const after = newRows[newIndex + 1]?.orderKey ?? null;
+    const newKey = generateKeyBetween(before, after);
+
+    setRows(
+      newRows.map((r) => (r.id === active.id ? { ...r, orderKey: newKey } : r))
+    );
   };
 
   const filteredRows = rows.filter((row) => {

--- a/src/app/admin/workshops/actions.ts
+++ b/src/app/admin/workshops/actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import prisma from '@/lib/prisma';
+import { WorkshopStatus } from '@prisma/client';
 
 export interface WorkshopRow {
   id: string;
@@ -16,6 +17,7 @@ export interface WorkshopRow {
   startDate: string;
   endDate: string;
   locationOrUrl: string | null;
+  orderKey: string;
 }
 
 export async function getWorkshops(): Promise<WorkshopRow[]> {
@@ -29,7 +31,7 @@ export async function getWorkshops(): Promise<WorkshopRow[]> {
       }
     },
     orderBy: {
-      createdAt: 'desc'
+      orderKey: 'asc'
     }
   });
 
@@ -62,10 +64,24 @@ export async function getWorkshops(): Promise<WorkshopRow[]> {
           .toISOString()
           .split('T')[0]
           .replace(/-/g, '.'),
-        locationOrUrl: workshop.locationOrUrl
+        locationOrUrl: workshop.locationOrUrl,
+        orderKey: workshop.orderKey
       };
     })
   );
 
   return workshopsWithData;
+}
+
+export async function updateWorkshopStatuses(
+  updates: { id: string; status: string }[]
+) {
+  await prisma.$transaction(
+    updates.map(({ id, status }) =>
+      prisma.workshop.update({
+        where: { id },
+        data: { status: status as WorkshopStatus }
+      })
+    )
+  );
 }

--- a/src/app/admin/workshops/page.tsx
+++ b/src/app/admin/workshops/page.tsx
@@ -5,7 +5,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { Checkbox } from '@/components/ui/checkbox';
 import PaceSelect from '@/components/ui/admin/select';
-import { getWorkshops, WorkshopRow } from './actions';
+import { getWorkshops, updateWorkshopStatuses, WorkshopRow } from './actions';
+import { generateKeyBetween } from 'fractional-indexing';
 import { toast } from 'sonner';
 
 import {
@@ -267,10 +268,43 @@ export default function Page() {
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
-    if (over && active.id !== over.id) {
-      const oldIndex = rows.findIndex((row) => row.id === active.id);
-      const newIndex = rows.findIndex((row) => row.id === over.id);
-      setRows((items) => arrayMove(items, oldIndex, newIndex));
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = rows.findIndex((row) => row.id === active.id);
+    const newIndex = rows.findIndex((row) => row.id === over.id);
+    const newRows = arrayMove(rows, oldIndex, newIndex);
+
+    const before = newRows[newIndex - 1]?.orderKey ?? null;
+    const after = newRows[newIndex + 1]?.orderKey ?? null;
+    const newKey = generateKeyBetween(before, after);
+
+    setRows(
+      newRows.map((r) => (r.id === active.id ? { ...r, orderKey: newKey } : r))
+    );
+  };
+
+  const handleSave = async () => {
+    try {
+      const statusUpdates = rows.map((r) => ({ id: r.id, status: r.status }));
+      const orderUpdates = rows.map((r) => ({
+        id: r.id,
+        orderKey: r.orderKey
+      }));
+
+      await Promise.all([
+        updateWorkshopStatuses(statusUpdates),
+        fetch('/api/workshops/reorder', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items: orderUpdates })
+        })
+      ]);
+
+      toast.success('저장되었습니다.');
+      const data = await getWorkshops();
+      setRows(data);
+    } catch {
+      toast.error('저장에 실패했습니다.');
     }
   };
 
@@ -284,8 +318,10 @@ export default function Page() {
     <div className="p-10">
       <div className="flex justify-between pb-10">
         <h1 className="text-pace-3xl font-bold">워크샵 관리</h1>
-        {/* TODO: DB 완료 후 저장 기능 추가 */}
-        <button className="bg-pace-orange-800 text-pace-white-500 text-pace-lg w-[140px] h-[60px] rounded">
+        <button
+          onClick={handleSave}
+          className="bg-pace-orange-800 text-pace-white-500 text-pace-lg w-[140px] h-[60px] rounded hover:bg-pace-orange-900 transition-colors"
+        >
           저장
         </button>
       </div>

--- a/src/app/api/courses/reorder/route.ts
+++ b/src/app/api/courses/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
+
+export async function PATCH(req: Request) {
+  try {
+    const body = await req.json();
+    const { items } = body as { items: { id: string; orderKey: string }[] };
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
+    }
+
+    const values = Prisma.join(
+      items.map(
+        (item) => Prisma.sql`(${item.id}::uuid, ${item.orderKey}::text)`
+      )
+    );
+
+    await prisma.$executeRaw`
+      UPDATE "Course" AS c
+      SET "orderKey" = v.order_key
+      FROM (VALUES ${values}) AS v(id, order_key)
+      WHERE c.id = v.id
+    `;
+
+    revalidatePath('/admin/courses');
+    revalidatePath('/courses');
+
+    return NextResponse.json({ message: 'Order updated' }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to reorder courses' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/courses/route.ts
+++ b/src/app/api/courses/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { ItemType, TargetAudienceType } from '@prisma/client';
+import { generateKeyBetween } from 'fractional-indexing';
 
 export async function GET() {
   try {
     const courses = await prisma.course.findMany({
       orderBy: {
-        createdAt: 'desc'
+        orderKey: 'asc'
       }
     });
 
@@ -58,8 +59,9 @@ export async function GET() {
       status: course.isPublic ? '공개중' : '비공개',
       thumbnail: course.thumbnailUrl || '',
       selected: false,
-      summary: course.description || '', // Keep mapping for UI compatibility if needed
-      category: course.category || 'NETWORKING'
+      summary: course.description || '',
+      category: course.category || 'NETWORKING',
+      orderKey: course.orderKey
     }));
 
     return NextResponse.json(rows, { status: 200 });
@@ -126,12 +128,19 @@ export async function POST(request: Request) {
       .map((label: string) => TARGET_AUDIENCE_MAP[label])
       .filter(Boolean);
 
+    const last = await prisma.course.findFirst({
+      orderBy: { orderKey: 'desc' },
+      select: { orderKey: true }
+    });
+    const nextKey = generateKeyBetween(last?.orderKey ?? null, null);
+
     // Perform creation in a transaction to ensure atomic execution and fix nested validation errors
     const newCourse = await prisma.$transaction(async (tx) => {
       // 1. Create the Course basic data and instructors
       const course = await tx.course.create({
         data: {
           category: category || 'NETWORKING',
+          orderKey: nextKey,
           isPublic,
           showOnMain,
           title,

--- a/src/app/api/ebooks/reorder/route.ts
+++ b/src/app/api/ebooks/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
+
+export async function PATCH(req: Request) {
+  try {
+    const body = await req.json();
+    const { items } = body as { items: { id: string; orderKey: string }[] };
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
+    }
+
+    const values = Prisma.join(
+      items.map(
+        (item) => Prisma.sql`(${item.id}::uuid, ${item.orderKey}::text)`
+      )
+    );
+
+    await prisma.$executeRaw`
+      UPDATE "Ebook" AS e
+      SET "orderKey" = v.order_key
+      FROM (VALUES ${values}) AS v(id, order_key)
+      WHERE e.id = v.id
+    `;
+
+    revalidatePath('/admin/ebooks');
+    revalidatePath('/ebooks');
+
+    return NextResponse.json({ message: 'Order updated' }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to reorder ebooks' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/ebooks/route.ts
+++ b/src/app/api/ebooks/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
         ...(isMainParam === 'true' ? { isMain: true } : {})
       },
       orderBy: {
-        uploadDate: 'desc'
+        orderKey: 'asc'
       }
     });
     const ebooks = ebookRecords.map((ebook) => ({

--- a/src/app/api/workshops/reorder/route.ts
+++ b/src/app/api/workshops/reorder/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+import { revalidatePath } from 'next/cache';
+
+export async function PATCH(req: Request) {
+  try {
+    const body = await req.json();
+    const { items } = body as { items: { id: string; orderKey: string }[] };
+
+    if (!Array.isArray(items) || items.length === 0) {
+      return NextResponse.json({ error: 'Invalid data' }, { status: 400 });
+    }
+
+    const values = Prisma.join(
+      items.map(
+        (item) => Prisma.sql`(${item.id}::uuid, ${item.orderKey}::text)`
+      )
+    );
+
+    await prisma.$executeRaw`
+      UPDATE "Workshop" AS w
+      SET "orderKey" = v.order_key
+      FROM (VALUES ${values}) AS v(id, order_key)
+      WHERE w.id = v.id
+    `;
+
+    revalidatePath('/admin/workshops');
+    revalidatePath('/workshops');
+
+    return NextResponse.json({ message: 'Order updated' }, { status: 200 });
+  } catch {
+    return NextResponse.json(
+      { error: 'Failed to reorder workshops' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/ebooks/actions/ebook-actions.ts
+++ b/src/components/admin/ebooks/actions/ebook-actions.ts
@@ -84,7 +84,6 @@ export async function createEbook(data: EbookData) {
 
     revalidatePath('/admin/ebooks');
   } catch (e) {
-    console.error('createEbook error:', e);
     throw new Error('Failed to create ebook');
   }
   redirect('/admin/ebooks');

--- a/src/components/admin/ebooks/actions/ebook-actions.ts
+++ b/src/components/admin/ebooks/actions/ebook-actions.ts
@@ -2,6 +2,7 @@
 
 import prisma from '@/lib/prisma';
 import { EbookCategory, TargetAudienceType } from '@prisma/client';
+import { generateKeyBetween } from 'fractional-indexing';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
@@ -53,6 +54,12 @@ export async function createEbook(data: EbookData) {
     // Filter out empty links (links are optional)
     const validLinks = links.filter((l) => l.url.trim() && l.name.trim());
 
+    const last = await prisma.ebook.findFirst({
+      orderBy: { orderKey: 'desc' },
+      select: { orderKey: true }
+    });
+    const nextKey = generateKeyBetween(last?.orderKey ?? null, null);
+
     await prisma.ebook.create({
       data: {
         ebookId: `ebook-${Date.now()}`,
@@ -70,12 +77,14 @@ export async function createEbook(data: EbookData) {
         visualTitle2: visualTitle2,
         targetAudienceTypes,
         tableOfContents: sections,
-        recommendedLinks: validLinks
+        recommendedLinks: validLinks,
+        orderKey: nextKey
       }
     });
 
     revalidatePath('/admin/ebooks');
-  } catch {
+  } catch (e) {
+    console.error('createEbook error:', e);
     throw new Error('Failed to create ebook');
   }
   redirect('/admin/ebooks');
@@ -140,7 +149,7 @@ export async function getEbooks(page = 1, limit = 10) {
   const ebooks = await prisma.ebook.findMany({
     skip,
     take: limit,
-    orderBy: [{ uploadDate: 'desc' }, { id: 'desc' }]
+    orderBy: [{ orderKey: 'asc' }]
   });
 
   if (ebooks.length === 0) {


### PR DESCRIPTION
## Why this PR:
- Adds admin-controlled display ordering for ebooks, courses, and workshops

## Changes:
  - Added orderKey field (fractional indexing string) to Ebook, Course, and Workshop models
  - New PATCH /api/ebooks/reorder, /api/courses/reorder, /api/workshops/reorder endpoints — single UPDATE FROM VALUES query per save
  - Wired up the existing drag-and-drop UI on all three admin pages so the 저장 button now persists order alongside status changes
  - Workshop save button was previously a no-op (TODO) — now fully functional for both status and order

## How to Test:
