### PR TITLE
[PACE-260] Checkout API, cart handoff, and post-payment UX

### DIFF
--- a/docs/stripe-payment-implementation-plan.md
+++ b/docs/stripe-payment-implementation-plan.md
@@ -136,6 +136,11 @@ Notes:
 - Handle `checkout.session.completed`.
 - Mark the matching order `COMPLETED` only after the payment is paid or no
   payment is required.
+- Reconcile final Stripe Checkout amounts into `Order` during webhook
+  fulfillment. Use Stripe's final session/payment values such as
+  `amount_subtotal`, `amount_total`, `total_details.amount_discount`, and
+  `total_details.amount_tax` so promotion-code purchases display the actual
+  charged amount in success, receipt, and purchase history views.
 - Store Stripe identifiers and receipt references.
 - Remove purchased items from the cart.
 - Grant workshop registration where relevant.
@@ -167,6 +172,9 @@ Notes:
 
 - Add unit/API tests for checkout session creation.
 - Add webhook tests with mocked Stripe signature construction.
+- Add webhook tests that verify promotion-code discounts update
+  `subtotalAmountCents`, `discountAmountCents`, `taxAmountCents`, and
+  `totalAmountCents` from Stripe's final amounts.
 - Add idempotency tests for duplicate webhook delivery.
 - Add entitlement tests for purchased and unpurchased content.
 - Validate locally with Stripe CLI:

--- a/docs/stripe-payment-implementation-plan.md
+++ b/docs/stripe-payment-implementation-plan.md
@@ -177,22 +177,22 @@ Notes:
 
 ## Jira Tickets
 
-| Step | Jira Key | Summary                                       |
-| ---- | -------- | --------------------------------------------- |
-| 1    | PACE-259 | Foundation: SDK, env, order schema            |
-| 2    | PACE-260 | Checkout creation: API + cart UI handoff      |
-| 3    | PACE-261 | Webhook fulfillment + purchase entitlements   |
-| 4    | PACE-262 | Post-payment UX: success, purchases, receipts |
-| 5    | PACE-263 | Test coverage and operational validation      |
+| Jira Key | Summary                                           | Scope                                                                 |
+| -------- | ------------------------------------------------- | --------------------------------------------------------------------- |
+| PACE-259 | Foundation: SDK, env, order schema                | Completed foundation work.                                            |
+| PACE-260 | Checkout API, cart handoff, and post-payment UX   | Steps 2 and 4, plus checkout and post-payment UX test coverage.       |
+| PACE-261 | Webhook fulfillment, entitlements, and validation | Steps 3 and 5, plus webhook, entitlement, and operational validation. |
 
 Superseded tickets:
 
-| Old Jira Key | Merged Into | Original Scope                           |
-| ------------ | ----------- | ---------------------------------------- |
-| PACE-264     | PACE-262    | Payment success and cancel pages         |
-| PACE-265     | PACE-261    | Purchase entitlements and access control |
-| PACE-266     | PACE-262    | Purchases, receipts, and refund UI       |
-| PACE-267     | PACE-263    | Tests and operational validation         |
+| Old Jira Key | Merged Into  | Original Scope                           |
+| ------------ | ------------ | ---------------------------------------- |
+| PACE-262     | PACE-260     | Post-payment UX, purchases, receipts     |
+| PACE-263     | PACE-260/261 | Tests and operational validation         |
+| PACE-264     | PACE-260     | Payment success and cancel pages         |
+| PACE-265     | PACE-261     | Purchase entitlements and access control |
+| PACE-266     | PACE-260     | Purchases, receipts, and refund UI       |
+| PACE-267     | PACE-260/261 | Tests and operational validation         |
 
 ## Definition of Done
 

--- a/src/app/api/stripe/create-checkout-session/route.test.ts
+++ b/src/app/api/stripe/create-checkout-session/route.test.ts
@@ -26,6 +26,7 @@ const tx = {
     findMany: vi.fn()
   },
   order: {
+    findFirst: vi.fn(),
     create: vi.fn()
   }
 };
@@ -41,6 +42,7 @@ const prismaMock = {
 };
 
 const stripeSessionCreateMock = vi.fn();
+const promotionCodesListMock = vi.fn();
 
 vi.mock('@/lib/prisma', () => ({
   default: prismaMock
@@ -52,6 +54,9 @@ vi.mock('@/lib/stripe', () => ({
       sessions: {
         create: stripeSessionCreateMock
       }
+    },
+    promotionCodes: {
+      list: promotionCodesListMock
     }
   }))
 }));
@@ -108,8 +113,12 @@ describe('POST /api/stripe/create-checkout-session', () => {
       thumbnailUrl: null
     });
     tx.orderItem.findMany.mockResolvedValue([]);
+    tx.order.findFirst.mockResolvedValue(null);
     tx.order.create.mockResolvedValue({
       id: orderId
+    });
+    promotionCodesListMock.mockResolvedValue({
+      data: []
     });
     stripeSessionCreateMock.mockResolvedValue({
       id: 'cs_test_123',
@@ -185,6 +194,7 @@ describe('POST /api/stripe/create-checkout-session', () => {
         mode: 'payment',
         client_reference_id: orderId,
         customer_email: 'buyer@example.com',
+        allow_promotion_codes: true,
         success_url:
           'http://localhost:3000/mypage/payment-success?session_id={CHECKOUT_SESSION_ID}',
         cancel_url: `http://localhost:3000/payment/cancel?order_id=${orderId}`
@@ -194,6 +204,67 @@ describe('POST /api/stripe/create-checkout-session', () => {
       where: { id: orderId },
       data: { stripeCheckoutSessionId: 'cs_test_123' }
     });
+  });
+
+  it('applies a validated Stripe promotion code to the checkout session', async () => {
+    promotionCodesListMock.mockResolvedValue({
+      data: [
+        {
+          id: 'promo_123',
+          code: 'SAVE10',
+          active: true,
+          customer: null,
+          customer_account: null,
+          expires_at: null,
+          max_redemptions: null,
+          times_redeemed: 0,
+          restrictions: {
+            currency_options: undefined,
+            first_time_transaction: false,
+            minimum_amount: null,
+            minimum_amount_currency: null
+          }
+        }
+      ]
+    });
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }],
+        promotionCode: 'SAVE10'
+      })
+    );
+
+    expect(response.status).toBe(201);
+    expect(promotionCodesListMock).toHaveBeenCalledWith({
+      code: 'SAVE10',
+      active: true,
+      limit: 10
+    });
+    expect(stripeSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        discounts: [{ promotion_code: 'promo_123' }],
+        metadata: expect.objectContaining({
+          promotionCode: 'SAVE10'
+        })
+      })
+    );
+  });
+
+  it('rejects invalid promotion codes before creating an order', async () => {
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }],
+        promotionCode: 'MISSING'
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Invalid promotion code'
+    });
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
   });
 
   it('rejects already purchased items before creating a Stripe session', async () => {

--- a/src/app/api/stripe/create-checkout-session/route.test.ts
+++ b/src/app/api/stripe/create-checkout-session/route.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+import type { Mock } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const tx = {
+  cart: {
+    findMany: vi.fn()
+  },
+  course: {
+    findUnique: vi.fn()
+  },
+  ebook: {
+    findFirst: vi.fn()
+  },
+  workshop: {
+    findUnique: vi.fn()
+  },
+  video: {
+    findFirst: vi.fn()
+  },
+  orderItem: {
+    findMany: vi.fn()
+  },
+  order: {
+    create: vi.fn()
+  }
+};
+
+const prismaMock = {
+  user: {
+    findUnique: vi.fn()
+  },
+  order: {
+    update: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+const stripeSessionCreateMock = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: vi.fn(() => ({
+    checkout: {
+      sessions: {
+        create: stripeSessionCreateMock
+      }
+    }
+  }))
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { POST } = await import('./route');
+
+function createRequest(body: unknown) {
+  return new Request(
+    'http://localhost:3000/api/stripe/create-checkout-session',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        origin: 'http://localhost:3000'
+      },
+      body: JSON.stringify(body)
+    }
+  );
+}
+
+describe('POST /api/stripe/create-checkout-session', () => {
+  const courseId = '11111111-1111-4111-8111-111111111111';
+  const orderId = '22222222-2222-4222-8222-222222222222';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+    (auth as unknown as Mock).mockResolvedValue({
+      userId: 'clerk_user_123'
+    });
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: '33333333-3333-4333-8333-333333333333',
+      email: 'buyer@example.com'
+    });
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(tx)
+    );
+    prismaMock.order.update.mockResolvedValue({});
+    tx.cart.findMany.mockResolvedValue([
+      {
+        id: 'cart-1',
+        itemId: courseId,
+        itemType: ItemType.COURSE
+      }
+    ]);
+    tx.course.findUnique.mockResolvedValue({
+      id: courseId,
+      title: 'Checkout Course',
+      description: 'Course description',
+      price: '49.99',
+      category: 'INTERVIEW',
+      thumbnailUrl: null
+    });
+    tx.orderItem.findMany.mockResolvedValue([]);
+    tx.order.create.mockResolvedValue({
+      id: orderId
+    });
+    stripeSessionCreateMock.mockResolvedValue({
+      id: 'cs_test_123',
+      url: 'https://checkout.stripe.test/session'
+    });
+  });
+
+  it('returns 401 when the user is not authenticated', async () => {
+    (auth as unknown as Mock).mockResolvedValue({ userId: null });
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('creates a pending order and Stripe checkout session', async () => {
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toMatchObject({
+      checkoutUrl: 'https://checkout.stripe.test/session',
+      orderId,
+      sessionId: 'cs_test_123',
+      totals: {
+        subtotalAmountCents: 4999,
+        discountAmountCents: 0,
+        taxAmountCents: 0,
+        totalAmountCents: 4999
+      }
+    });
+    expect(tx.order.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: '33333333-3333-4333-8333-333333333333',
+          status: OrderStatus.PENDING,
+          totalAmountCents: 4999,
+          items: {
+            create: [
+              {
+                itemId: courseId,
+                itemType: ItemType.COURSE,
+                priceAtPurchaseCents: 4999,
+                quantity: 1
+              }
+            ]
+          }
+        })
+      })
+    );
+    expect(stripeSessionCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'payment',
+        client_reference_id: orderId,
+        customer_email: 'buyer@example.com',
+        success_url:
+          'http://localhost:3000/mypage/payment-success?session_id={CHECKOUT_SESSION_ID}',
+        cancel_url: `http://localhost:3000/payment/cancel?order_id=${orderId}`
+      })
+    );
+    expect(prismaMock.order.update).toHaveBeenCalledWith({
+      where: { id: orderId },
+      data: { stripeCheckoutSessionId: 'cs_test_123' }
+    });
+  });
+
+  it('rejects already purchased items before creating a Stripe session', async () => {
+    tx.orderItem.findMany.mockResolvedValue([
+      {
+        itemId: courseId,
+        itemType: ItemType.COURSE
+      }
+    ]);
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'Already purchased: Checkout Course'
+    });
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/stripe/create-checkout-session/route.test.ts
+++ b/src/app/api/stripe/create-checkout-session/route.test.ts
@@ -131,6 +131,17 @@ describe('POST /api/stripe/create-checkout-session', () => {
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
+  it('rejects empty checkout selections', async () => {
+    const response = await POST(createRequest({ selectedItems: [] }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'No checkout items selected'
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+
   it('creates a pending order and Stripe checkout session', async () => {
     const response = await POST(
       createRequest({
@@ -205,5 +216,86 @@ describe('POST /api/stripe/create-checkout-session', () => {
     });
     expect(tx.order.create).not.toHaveBeenCalled();
     expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects selected items that are no longer in the cart', async () => {
+    tx.cart.findMany.mockResolvedValue([]);
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Selected cart items were not found'
+    });
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects cart items that no longer resolve to catalog content', async () => {
+    tx.course.findUnique.mockResolvedValue(null);
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'One or more selected items are unavailable'
+    });
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects checkout items with invalid prices', async () => {
+    tx.course.findUnique.mockResolvedValue({
+      id: courseId,
+      title: 'Checkout Course',
+      description: 'Course description',
+      price: '0',
+      category: 'INTERVIEW',
+      thumbnailUrl: null
+    });
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Checkout Course has an invalid price'
+    });
+    expect(tx.order.create).not.toHaveBeenCalled();
+    expect(stripeSessionCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('marks the pending order failed when Stripe does not return a URL', async () => {
+    stripeSessionCreateMock.mockResolvedValue({
+      id: 'cs_test_123',
+      url: null
+    });
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }]
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      error:
+        'Failed to create checkout session: Stripe did not return a checkout URL'
+    });
+    expect(prismaMock.order.update).toHaveBeenCalledWith({
+      where: { id: orderId },
+      data: { status: OrderStatus.FAILED }
+    });
   });
 });

--- a/src/app/api/stripe/create-checkout-session/route.test.ts
+++ b/src/app/api/stripe/create-checkout-session/route.test.ts
@@ -290,8 +290,7 @@ describe('POST /api/stripe/create-checkout-session', () => {
 
     expect(response.status).toBe(500);
     expect(await response.json()).toEqual({
-      error:
-        'Failed to create checkout session: Stripe did not return a checkout URL'
+      error: 'Failed to create checkout session'
     });
     expect(prismaMock.order.update).toHaveBeenCalledWith({
       where: { id: orderId },

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -56,13 +56,8 @@ function errorResponse(error: unknown) {
     );
   }
 
-  const message =
-    error instanceof Error
-      ? error.message
-      : 'Failed to create checkout session';
-
   return NextResponse.json(
-    { error: `Failed to create checkout session: ${message}` },
+    { error: 'Failed to create checkout session' },
     { status: 500 }
   );
 }

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -1,0 +1,192 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { OrderStatus } from '@prisma/client';
+import type Stripe from 'stripe';
+import {
+  assertNoCompletedPurchases,
+  calculateCheckoutTotals,
+  CHECKOUT_CURRENCY,
+  CheckoutCartItem,
+  CheckoutError,
+  getCheckoutCartItems,
+  parseCheckoutSelections
+} from '@/lib/checkout-items';
+import {
+  buildCheckoutSuccessUrl,
+  getAppBaseUrl,
+  getMetadataValue,
+  toAbsoluteUrl
+} from '@/lib/checkout-utils';
+import prisma from '@/lib/prisma';
+import { getStripeClient } from '@/lib/stripe';
+
+export const runtime = 'nodejs';
+
+function buildCheckoutLineItems(
+  items: CheckoutCartItem[]
+): Stripe.Checkout.SessionCreateParams.LineItem[] {
+  return items.map((item) => ({
+    quantity: item.quantity,
+    price_data: {
+      currency: CHECKOUT_CURRENCY,
+      unit_amount: item.unitAmountCents,
+      product_data: {
+        name: getMetadataValue(item.title),
+        metadata: {
+          itemId: getMetadataValue(item.itemId),
+          itemType: getMetadataValue(item.itemType)
+        }
+      }
+    }
+  }));
+}
+
+function buildItemSummary(items: CheckoutCartItem[]) {
+  return items
+    .map((item) => `${item.itemType}:${item.itemId}`)
+    .join(',')
+    .slice(0, 500);
+}
+
+function errorResponse(error: unknown) {
+  if (error instanceof CheckoutError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status }
+    );
+  }
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : 'Failed to create checkout session';
+
+  return NextResponse.json(
+    { error: `Failed to create checkout session: ${message}` },
+    { status: 500 }
+  );
+}
+
+export async function POST(req: Request) {
+  let pendingOrderId: string | null = null;
+
+  try {
+    const { userId: clerkUserId } = await auth();
+
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => {
+      throw new CheckoutError('Invalid request body', 400);
+    });
+    const selections = parseCheckoutSelections(body);
+
+    const currentUser = await prisma.user.findUnique({
+      where: { clerkId: clerkUserId },
+      select: {
+        id: true,
+        email: true
+      }
+    });
+
+    if (!currentUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const preparedCheckout = await prisma.$transaction(async (tx) => {
+      const checkoutItems = await getCheckoutCartItems(
+        tx,
+        currentUser.id,
+        selections
+      );
+      await assertNoCompletedPurchases(tx, currentUser.id, checkoutItems);
+
+      const totals = calculateCheckoutTotals(checkoutItems);
+      const order = await tx.order.create({
+        data: {
+          userId: currentUser.id,
+          currency: CHECKOUT_CURRENCY,
+          status: OrderStatus.PENDING,
+          totalAmountCents: totals.totalAmountCents,
+          subtotalAmountCents: totals.subtotalAmountCents,
+          discountAmountCents: totals.discountAmountCents,
+          taxAmountCents: totals.taxAmountCents,
+          items: {
+            create: checkoutItems.map((item) => ({
+              itemId: item.itemId,
+              itemType: item.itemType,
+              priceAtPurchaseCents: item.unitAmountCents,
+              quantity: item.quantity
+            }))
+          }
+        }
+      });
+
+      return {
+        checkoutItems,
+        order,
+        totals
+      };
+    });
+
+    pendingOrderId = preparedCheckout.order.id;
+
+    const appBaseUrl = getAppBaseUrl(req);
+    const stripe = getStripeClient();
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: buildCheckoutLineItems(preparedCheckout.checkoutItems),
+      success_url: buildCheckoutSuccessUrl(
+        appBaseUrl,
+        '/mypage/payment-success'
+      ),
+      cancel_url: toAbsoluteUrl(
+        appBaseUrl,
+        `/payment/cancel?order_id=${preparedCheckout.order.id}`
+      ),
+      client_reference_id: preparedCheckout.order.id,
+      customer_email: currentUser.email,
+      metadata: {
+        orderId: getMetadataValue(preparedCheckout.order.id),
+        userId: getMetadataValue(currentUser.id),
+        clerkUserId: getMetadataValue(clerkUserId),
+        itemSummary: getMetadataValue(
+          buildItemSummary(preparedCheckout.checkoutItems)
+        )
+      }
+    });
+
+    if (!session.url) {
+      throw new Error('Stripe did not return a checkout URL');
+    }
+
+    await prisma.order.update({
+      where: { id: preparedCheckout.order.id },
+      data: {
+        stripeCheckoutSessionId: session.id
+      }
+    });
+
+    return NextResponse.json(
+      {
+        checkoutUrl: session.url,
+        orderId: preparedCheckout.order.id,
+        sessionId: session.id,
+        totals: preparedCheckout.totals
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    if (pendingOrderId && !(error instanceof CheckoutError)) {
+      await prisma.order
+        .update({
+          where: { id: pendingOrderId },
+          data: { status: OrderStatus.FAILED }
+        })
+        .catch(() => undefined);
+    }
+
+    return errorResponse(error);
+  }
+}

--- a/src/app/api/stripe/create-checkout-session/route.ts
+++ b/src/app/api/stripe/create-checkout-session/route.ts
@@ -19,6 +19,10 @@ import {
 } from '@/lib/checkout-utils';
 import prisma from '@/lib/prisma';
 import { getStripeClient } from '@/lib/stripe';
+import {
+  parseOptionalPromotionCode,
+  validateStripePromotionCode
+} from '@/lib/stripe-promotion-codes';
 
 export const runtime = 'nodejs';
 
@@ -76,6 +80,7 @@ export async function POST(req: Request) {
       throw new CheckoutError('Invalid request body', 400);
     });
     const selections = parseCheckoutSelections(body);
+    const promotionCode = parseOptionalPromotionCode(body);
 
     const currentUser = await prisma.user.findUnique({
       where: { clerkId: clerkUserId },
@@ -98,17 +103,44 @@ export async function POST(req: Request) {
       await assertNoCompletedPurchases(tx, currentUser.id, checkoutItems);
 
       const totals = calculateCheckoutTotals(checkoutItems);
-      const order = await tx.order.create({
+      const completedOrder = await tx.order.findFirst({
+        where: {
+          userId: currentUser.id,
+          status: OrderStatus.COMPLETED
+        },
+        select: { id: true }
+      });
+
+      return {
+        checkoutItems,
+        hasCompletedOrder: Boolean(completedOrder),
+        totals
+      };
+    });
+
+    const appBaseUrl = getAppBaseUrl(req);
+    const stripe = getStripeClient();
+    const validatedPromotionCode = promotionCode
+      ? await validateStripePromotionCode(stripe, {
+          code: promotionCode,
+          subtotalAmountCents: preparedCheckout.totals.subtotalAmountCents,
+          currency: CHECKOUT_CURRENCY,
+          hasCompletedOrder: preparedCheckout.hasCompletedOrder
+        })
+      : null;
+
+    const order = await prisma.$transaction(async (tx) =>
+      tx.order.create({
         data: {
           userId: currentUser.id,
           currency: CHECKOUT_CURRENCY,
           status: OrderStatus.PENDING,
-          totalAmountCents: totals.totalAmountCents,
-          subtotalAmountCents: totals.subtotalAmountCents,
-          discountAmountCents: totals.discountAmountCents,
-          taxAmountCents: totals.taxAmountCents,
+          totalAmountCents: preparedCheckout.totals.totalAmountCents,
+          subtotalAmountCents: preparedCheckout.totals.subtotalAmountCents,
+          discountAmountCents: preparedCheckout.totals.discountAmountCents,
+          taxAmountCents: preparedCheckout.totals.taxAmountCents,
           items: {
-            create: checkoutItems.map((item) => ({
+            create: preparedCheckout.checkoutItems.map((item) => ({
               itemId: item.itemId,
               itemType: item.itemType,
               priceAtPurchaseCents: item.unitAmountCents,
@@ -116,19 +148,11 @@ export async function POST(req: Request) {
             }))
           }
         }
-      });
+      })
+    );
 
-      return {
-        checkoutItems,
-        order,
-        totals
-      };
-    });
+    pendingOrderId = order.id;
 
-    pendingOrderId = preparedCheckout.order.id;
-
-    const appBaseUrl = getAppBaseUrl(req);
-    const stripe = getStripeClient();
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       line_items: buildCheckoutLineItems(preparedCheckout.checkoutItems),
@@ -138,14 +162,18 @@ export async function POST(req: Request) {
       ),
       cancel_url: toAbsoluteUrl(
         appBaseUrl,
-        `/payment/cancel?order_id=${preparedCheckout.order.id}`
+        `/payment/cancel?order_id=${order.id}`
       ),
-      client_reference_id: preparedCheckout.order.id,
+      client_reference_id: order.id,
       customer_email: currentUser.email,
+      ...(validatedPromotionCode
+        ? { discounts: [{ promotion_code: validatedPromotionCode.id }] }
+        : { allow_promotion_codes: true }),
       metadata: {
-        orderId: getMetadataValue(preparedCheckout.order.id),
+        orderId: getMetadataValue(order.id),
         userId: getMetadataValue(currentUser.id),
         clerkUserId: getMetadataValue(clerkUserId),
+        promotionCode: getMetadataValue(validatedPromotionCode?.code),
         itemSummary: getMetadataValue(
           buildItemSummary(preparedCheckout.checkoutItems)
         )
@@ -157,7 +185,7 @@ export async function POST(req: Request) {
     }
 
     await prisma.order.update({
-      where: { id: preparedCheckout.order.id },
+      where: { id: order.id },
       data: {
         stripeCheckoutSessionId: session.id
       }
@@ -166,7 +194,7 @@ export async function POST(req: Request) {
     return NextResponse.json(
       {
         checkoutUrl: session.url,
-        orderId: preparedCheckout.order.id,
+        orderId: order.id,
         sessionId: session.id,
         totals: preparedCheckout.totals
       },

--- a/src/app/api/stripe/validate-promotion-code/route.test.ts
+++ b/src/app/api/stripe/validate-promotion-code/route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+import type { Mock } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const tx = {
+  cart: {
+    findMany: vi.fn()
+  },
+  course: {
+    findUnique: vi.fn()
+  },
+  ebook: {
+    findFirst: vi.fn()
+  },
+  workshop: {
+    findUnique: vi.fn()
+  },
+  video: {
+    findFirst: vi.fn()
+  },
+  orderItem: {
+    findMany: vi.fn()
+  },
+  order: {
+    findFirst: vi.fn()
+  }
+};
+
+const prismaMock = {
+  user: {
+    findUnique: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+const promotionCodesListMock = vi.fn();
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: vi.fn(() => ({
+    promotionCodes: {
+      list: promotionCodesListMock
+    }
+  }))
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { POST } = await import('./route');
+
+function createRequest(body: unknown) {
+  return new Request(
+    'http://localhost:3000/api/stripe/validate-promotion-code',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    }
+  );
+}
+
+describe('POST /api/stripe/validate-promotion-code', () => {
+  const courseId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (auth as unknown as Mock).mockResolvedValue({
+      userId: 'clerk_user_123'
+    });
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: '33333333-3333-4333-8333-333333333333'
+    });
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(tx)
+    );
+    tx.cart.findMany.mockResolvedValue([
+      {
+        id: 'cart-1',
+        itemId: courseId,
+        itemType: ItemType.COURSE
+      }
+    ]);
+    tx.course.findUnique.mockResolvedValue({
+      id: courseId,
+      title: 'Checkout Course',
+      description: 'Course description',
+      price: '49.99',
+      category: 'INTERVIEW',
+      thumbnailUrl: null
+    });
+    tx.orderItem.findMany.mockResolvedValue([]);
+    tx.order.findFirst.mockResolvedValue(null);
+    promotionCodesListMock.mockResolvedValue({
+      data: [
+        {
+          id: 'promo_123',
+          code: 'SAVE10',
+          active: true,
+          customer: null,
+          customer_account: null,
+          expires_at: null,
+          max_redemptions: null,
+          times_redeemed: 0,
+          restrictions: {
+            currency_options: undefined,
+            first_time_transaction: false,
+            minimum_amount: null,
+            minimum_amount_currency: null
+          }
+        }
+      ]
+    });
+  });
+
+  it('validates an active public Stripe promotion code', async () => {
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }],
+        promotionCode: 'SAVE10'
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      promotionCode: {
+        code: 'SAVE10'
+      }
+    });
+    expect(tx.order.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: '33333333-3333-4333-8333-333333333333',
+        status: OrderStatus.COMPLETED
+      },
+      select: { id: true }
+    });
+    expect(promotionCodesListMock).toHaveBeenCalledWith({
+      code: 'SAVE10',
+      active: true,
+      limit: 10
+    });
+  });
+
+  it('rejects missing Stripe promotion codes', async () => {
+    promotionCodesListMock.mockResolvedValue({ data: [] });
+
+    const response = await POST(
+      createRequest({
+        selectedItems: [{ itemId: courseId, itemType: ItemType.COURSE }],
+        promotionCode: 'MISSING'
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Invalid promotion code'
+    });
+  });
+});

--- a/src/app/api/stripe/validate-promotion-code/route.ts
+++ b/src/app/api/stripe/validate-promotion-code/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { OrderStatus } from '@prisma/client';
+import {
+  assertNoCompletedPurchases,
+  calculateCheckoutTotals,
+  CHECKOUT_CURRENCY,
+  CheckoutError,
+  getCheckoutCartItems,
+  parseCheckoutSelections
+} from '@/lib/checkout-items';
+import prisma from '@/lib/prisma';
+import { getStripeClient } from '@/lib/stripe';
+import {
+  parseOptionalPromotionCode,
+  validateStripePromotionCode
+} from '@/lib/stripe-promotion-codes';
+
+export const runtime = 'nodejs';
+
+function errorResponse(error: unknown) {
+  if (error instanceof CheckoutError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status }
+    );
+  }
+
+  return NextResponse.json(
+    { error: 'Failed to validate promotion code' },
+    { status: 500 }
+  );
+}
+
+export async function POST(req: Request) {
+  try {
+    const { userId: clerkUserId } = await auth();
+
+    if (!clerkUserId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => {
+      throw new CheckoutError('Invalid request body', 400);
+    });
+    const selections = parseCheckoutSelections(body);
+    const promotionCode = parseOptionalPromotionCode(body);
+
+    if (!promotionCode) {
+      throw new CheckoutError('Promotion code is required', 400);
+    }
+
+    const currentUser = await prisma.user.findUnique({
+      where: { clerkId: clerkUserId },
+      select: { id: true }
+    });
+
+    if (!currentUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const checkoutState = await prisma.$transaction(async (tx) => {
+      const checkoutItems = await getCheckoutCartItems(
+        tx,
+        currentUser.id,
+        selections
+      );
+      await assertNoCompletedPurchases(tx, currentUser.id, checkoutItems);
+
+      const totals = calculateCheckoutTotals(checkoutItems);
+      const completedOrder = await tx.order.findFirst({
+        where: {
+          userId: currentUser.id,
+          status: OrderStatus.COMPLETED
+        },
+        select: { id: true }
+      });
+
+      return {
+        hasCompletedOrder: Boolean(completedOrder),
+        totals
+      };
+    });
+
+    const validatedPromotionCode = await validateStripePromotionCode(
+      getStripeClient(),
+      {
+        code: promotionCode,
+        subtotalAmountCents: checkoutState.totals.subtotalAmountCents,
+        currency: CHECKOUT_CURRENCY,
+        hasCompletedOrder: checkoutState.hasCompletedOrder
+      }
+    );
+
+    return NextResponse.json({
+      promotionCode: {
+        code: validatedPromotionCode.code
+      }
+    });
+  } catch (error) {
+    return errorResponse(error);
+  }
+}

--- a/src/app/mypage/payment-success/page.tsx
+++ b/src/app/mypage/payment-success/page.tsx
@@ -132,6 +132,9 @@ export default async function PaymentSuccess({
     return <EmptyState hasSessionId={Boolean(sessionId)} />;
   }
 
+  const isFinalizedOrder = order.status === 'COMPLETED';
+  const amountLabel = isFinalizedOrder ? '총 결제 금액' : '주문 기준 금액';
+
   return (
     <section className="flex-1 p-10 pt-20">
       <h1 className="mb-20 text-pace-xl font-bold text-pace-gray-700">
@@ -156,9 +159,14 @@ export default async function PaymentSuccess({
           입니다.
         </p>
         <p className="text-pace-base font-semibold text-pace-gray-700">
-          총 결제 금액:{' '}
+          {amountLabel}:{' '}
           {formatMoneyFromCents(order.totalAmountCents, order.currency)}
         </p>
+        {!isFinalizedOrder && (
+          <p className="text-pace-sm text-pace-stone-500">
+            프로모션 할인 및 최종 청구 금액은 Stripe 결제 내역에서 확인됩니다.
+          </p>
+        )}
       </div>
 
       <div className="flex mt-6 gap-4 items-center justify-center text-center">

--- a/src/app/mypage/payment-success/page.tsx
+++ b/src/app/mypage/payment-success/page.tsx
@@ -1,46 +1,137 @@
 import Image from 'next/image';
-import { CustomBadge } from '@/components/common/custom-badge';
-import { CartItem } from '@/types/my-card';
 import Link from 'next/link';
+import { auth } from '@clerk/nextjs/server';
+import { CustomBadge } from '@/components/common/custom-badge';
+import { itemCategoryLabel } from '@/constants/labels';
+import { getOrderDisplayBySessionId, OrderDisplay } from '@/lib/order-display';
+import { formatMoneyFromCents } from '@/lib/money';
+import prisma from '@/lib/prisma';
+import { resolveImageSrc } from '@/lib/utils';
 
-const items: CartItem[] = [
-  {
-    id: '1',
-    itemId: '4e8wv1z7tl',
-    title: 'UX Design Fundamentals',
-    price: 2800,
-    category: 'Marketing',
-    type: '전자책'
-  },
-  {
-    id: '2',
-    itemId: '4e8wv1z7tl',
-    title: 'UX Design Fundamentals',
-    price: 15.99,
-    category: 'Interview',
-    type: '온라인 강의'
-  },
-  {
-    id: '3',
-    itemId: '4e8wv1z7tl',
-    title: '성공을 부르는 마인드 트레이닝',
-    price: 20,
-    category: '',
-    date: new Date('2025-05-10'),
-    type: '워크샵'
-  },
-  {
-    id: '4',
-    itemId: '4e8wv1z7tl',
-    title: 'Test3',
-    price: 9.57,
-    category: 'Resume',
-    type: '온라인 강의'
+type PaymentSuccessProps = {
+  searchParams: Promise<{
+    session_id?: string | string[];
+  }>;
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function getOrder(sessionId: string | undefined) {
+  if (!sessionId) return null;
+
+  const { userId: clerkUserId } = await auth();
+  if (!clerkUserId) return null;
+
+  const currentUser = await prisma.user.findUnique({
+    where: { clerkId: clerkUserId },
+    select: { id: true }
+  });
+
+  if (!currentUser) return null;
+
+  return getOrderDisplayBySessionId(sessionId, currentUser.id);
+}
+
+function EmptyState({ hasSessionId }: { hasSessionId: boolean }) {
+  return (
+    <section className="flex-1 p-10 pt-20">
+      <h1 className="mb-20 text-pace-xl font-bold text-pace-gray-700">
+        장바구니
+      </h1>
+      <div className="flex flex-col gap-4 items-center justify-center text-center">
+        <h2 className="text-[20px] font-medium text-pace-gray-700">
+          결제 정보를 찾을 수 없습니다.
+        </h2>
+        <p className="text-pace-stone-500">
+          {hasSessionId
+            ? '현재 계정에서 확인할 수 있는 주문이 없습니다.'
+            : 'Stripe 결제 세션 정보가 없습니다.'}
+        </p>
+        <Link
+          href="/mypage/cart"
+          className="mt-4 bg-pace-orange-800 px-10 py-4 rounded-full text-pace-white-500 hover:bg-pace-orange-600"
+        >
+          장바구니로 돌아가기
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+function OrderItems({ order }: { order: OrderDisplay }) {
+  return (
+    <div className="mt-20 space-y-4 text-[20px] text-pace-gray-500">
+      {order.items.map((item, index) => {
+        const imageSrc =
+          resolveImageSrc({
+            thumbnail: item.thumbnail,
+            itemType: item.itemType
+          }) || '/img/resume_lecture.jpeg';
+        const category =
+          item.category &&
+          (itemCategoryLabel.en[item.category] ?? item.category);
+
+        return (
+          <div
+            key={item.id}
+            className={`flex items-center border-b p-4 !m-0 ${index === 0 ? 'border-t' : ''}`}
+          >
+            <div className="w-20 h-4 text-pace-sm text-center text-pace-stone-500 mx-6">
+              {item.typeLabel}
+            </div>
+            <Image
+              src={imageSrc}
+              alt={item.title}
+              width={160}
+              height={106}
+              className="w-40 h-[106px] rounded-lg object-cover"
+            />
+            <div className="ml-6">
+              {category && (
+                <CustomBadge
+                  variant={category}
+                  className="w-fit flex justify-center items-center py-2 px-3"
+                >
+                  {category}
+                </CustomBadge>
+              )}
+              {item.startsAt && (
+                <div className="text-pace-sm">
+                  {item.startsAt.toISOString().slice(0, 10).replace(/-/g, '.')}
+                </div>
+              )}
+
+              <div className="mt-2">{item.title}</div>
+              <div className="mt-2 font-bold text-pace-gray-500 text-pace-lg">
+                {formatMoneyFromCents(item.priceCents, order.currency)}
+              </div>
+            </div>
+            <Link
+              href={item.actionHref}
+              className="min-w-[120px] p-4 text-center ml-auto bg-pace-orange-500 rounded-full text-pace-base text-pace-white-500 font-regular"
+            >
+              {item.actionLabel}
+            </Link>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default async function PaymentSuccess({
+  searchParams
+}: PaymentSuccessProps) {
+  const params = await searchParams;
+  const sessionId = firstParam(params.session_id);
+  const order = await getOrder(sessionId);
+
+  if (!order) {
+    return <EmptyState hasSessionId={Boolean(sessionId)} />;
   }
-];
 
-export default function PaymentSuccess() {
-  const paymentNumber = 'AA0000';
   return (
     <section className="flex-1 p-10 pt-20">
       <h1 className="mb-20 text-pace-xl font-bold text-pace-gray-700">
@@ -53,12 +144,20 @@ export default function PaymentSuccess() {
           width={32}
           height={32}
         />
-        <h1 className="text-[20px] font-medium text-pace-gray-700">결제완료</h1>
+        <h2 className="text-[20px] font-medium text-pace-gray-700">
+          {order.status === 'COMPLETED' ? '결제완료' : order.statusLabel}
+        </h2>
         <p className="text-pace-stone-500">
-          결제가 완료되었습니다.
+          주문 정보가 접수되었습니다.
           <br />
-          결제번호는 <span className="font-semibold">{paymentNumber}</span>{' '}
+          주문번호는 <span className="font-semibold">
+            {order.orderNumber}
+          </span>{' '}
           입니다.
+        </p>
+        <p className="text-pace-base font-semibold text-pace-gray-700">
+          총 결제 금액:{' '}
+          {formatMoneyFromCents(order.totalAmountCents, order.currency)}
         </p>
       </div>
 
@@ -77,57 +176,7 @@ export default function PaymentSuccess() {
         </Link>
       </div>
 
-      <div className="mt-20 space-y-4 text-[20px] text-pace-gray-500">
-        {items.map((item, index) => (
-          <div
-            key={item.id}
-            className={`flex items-center border-b p-4 !m-0 ${index == 0 ? 'border-t' : ''}`}
-          >
-            <div className="w-20 h-4 text-pace-sm text-center text-pace-stone-500 mx-6">
-              {item.type}
-            </div>
-            <Image
-              src="/img/resume_lecture.jpeg"
-              alt={item.title}
-              width={160}
-              height={106}
-              className="w-40 h-[106px] rounded-lg object-cover"
-            />
-            <div className="ml-6">
-              {item.category && (
-                <CustomBadge
-                  variant={item.category}
-                  className="w-fit flex justify-center items-center py-2 px-3"
-                >
-                  {item.category}
-                </CustomBadge>
-              )}
-              {item.date && (
-                <div className="text-pace-sm">
-                  {item.date && (
-                    <div className="text-pace-sm">
-                      {item.date.toISOString().slice(0, 10).replace(/-/g, '.')}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              <div className="mt-2">{item.title}</div>
-              <div className="mt-2 font-bold text-pace-gray-500 text-pace-lg">
-                ${item.price}
-              </div>
-            </div>
-            <Link
-              href="/purchase"
-              className="min-w-[120px] p-4 text-center ml-auto bg-pace-orange-500 rounded-full text-pace-base text-pace-white-500 font-regular"
-            >
-              {item.type === '워크샵' ? 'View detail' : '수강하러 가기'}
-            </Link>
-
-            <button className=""></button>
-          </div>
-        ))}
-      </div>
+      <OrderItems order={order} />
     </section>
   );
 }

--- a/src/app/mypage/purchases/page.tsx
+++ b/src/app/mypage/purchases/page.tsx
@@ -1,67 +1,66 @@
+import { auth } from '@clerk/nextjs/server';
 import PurchasesList from '@/components/features/mypage/purchases/purchases-list';
+import { getOrderDisplaysForUser } from '@/lib/order-display';
+import prisma from '@/lib/prisma';
 
-export default function Purchases() {
-  const orders = [
-    {
-      orderNumber: 'AA1000001',
-      items: [
-        'UX Design Fundamentals',
-        '자기소개서 작성 및 면접 준비까지 하나로!'
-      ],
-      amount: 4320,
-      status: '결제완료',
-      date: new Date(2025, 7, 1)
-    },
-    {
-      orderNumber: 'AA1000002',
-      items: [
-        '자기소개서 작성 및 면접 준비까지 하나로!',
-        '자기소개서 작성 및 면접 준비까지 하나로!'
-      ],
-      amount: 2800,
-      status: '환불진행중',
-      date: new Date(2025, 7, 3)
-    },
-    {
-      orderNumber: 'AA1000003',
-      items: [
-        '자기소개서 작성 및 면접 준비까지 하나로!',
-        '자기소개서 작성 및 면접 준비까지 하나로!'
-      ],
-      amount: 2800,
-      status: '환불완료',
-      date: new Date(2025, 7, 5)
-    },
-    {
-      orderNumber: 'AA1000004',
-      items: [
-        '자기소개서 작성 및 면접 준비까지 하나로!',
-        '자기소개서 작성 및 면접 준비까지 하나로!'
-      ],
-      amount: 2800,
-      status: '환불진행중',
-      date: new Date(2025, 7, 6)
-    },
-    {
-      orderNumber: 'AA1000005',
-      items: [
-        '자기소개서 작성 및 면접 준비까지 하나로!',
-        '자기소개서 작성 및 면접 준비까지 하나로!'
-      ],
-      amount: 2800,
-      status: '환불완료',
-      date: new Date(2025, 7, 10)
-    }
-  ];
+async function getCurrentUserOrders() {
+  const { userId: clerkUserId } = await auth();
+  if (!clerkUserId) return [];
+
+  const currentUser = await prisma.user.findUnique({
+    where: { clerkId: clerkUserId },
+    select: { id: true }
+  });
+
+  if (!currentUser) return [];
+
+  return getOrderDisplaysForUser(currentUser.id);
+}
+
+export default async function Purchases() {
+  const orders = await getCurrentUserOrders();
 
   return (
     <main className="mx-10 mt-20 mb-auto">
       <h1 className="text-pace-xl font-bold mb-6 text-pace-gray-700">
         구매내역
       </h1>
-      {orders.map((order, idx) => (
-        <PurchasesList key={idx} {...order} isFirst={idx === 0} />
-      ))}
+      {orders.length > 0 ? (
+        orders.map((order, idx) => (
+          <PurchasesList
+            key={order.id}
+            orderNumber={order.orderNumber}
+            items={order.items.map((item) => ({
+              id: item.id,
+              type: item.typeLabel,
+              title: item.title,
+              priceCents: item.priceCents,
+              quantity: item.quantity
+            }))}
+            amountCents={order.totalAmountCents}
+            status={order.status}
+            statusLabel={order.statusLabel}
+            date={order.orderedAt.toISOString().split('T')[0]}
+            currency={order.currency}
+            payment={{
+              subtotalCents: order.subtotalAmountCents,
+              discountCents: order.discountAmountCents,
+              taxCents: order.taxAmountCents,
+              method: 'Stripe Checkout',
+              installment: '-',
+              card: '-',
+              totalCents: order.totalAmountCents,
+              currency: order.currency
+            }}
+            receiptUrl={order.stripeReceiptUrl || order.stripeInvoiceUrl}
+            isFirst={idx === 0}
+          />
+        ))
+      ) : (
+        <p className="border-t border-pace-gray-700 py-10 text-pace-stone-500">
+          구매내역이 없습니다.
+        </p>
+      )}
     </main>
   );
 }

--- a/src/app/mypage/purchases/page.tsx
+++ b/src/app/mypage/purchases/page.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@clerk/nextjs/server';
+import { OrderStatus } from '@prisma/client';
 import PurchasesList from '@/components/features/mypage/purchases/purchases-list';
 import { getOrderDisplaysForUser } from '@/lib/order-display';
 import prisma from '@/lib/prisma';
@@ -14,7 +15,10 @@ async function getCurrentUserOrders() {
 
   if (!currentUser) return [];
 
-  return getOrderDisplaysForUser(currentUser.id);
+  return getOrderDisplaysForUser(currentUser.id, [
+    OrderStatus.COMPLETED,
+    OrderStatus.REFUNDED
+  ]);
 }
 
 export default async function Purchases() {

--- a/src/app/payment/cancel/page.tsx
+++ b/src/app/payment/cancel/page.tsx
@@ -78,11 +78,14 @@ export default async function PaymentCancel({
             ))}
           </ul>
           <div className="mt-6 flex justify-between border-t border-pace-gray-100 pt-6 text-[20px] font-semibold text-pace-gray-700">
-            <span>총 결제 금액</span>
+            <span>주문 기준 금액</span>
             <span>
               {formatMoneyFromCents(order.totalAmountCents, order.currency)}
             </span>
           </div>
+          <p className="mt-3 text-right text-pace-sm text-pace-stone-500">
+            프로모션 할인 및 최종 청구 금액은 Stripe Checkout에서 확정됩니다.
+          </p>
         </div>
       )}
 

--- a/src/app/payment/cancel/page.tsx
+++ b/src/app/payment/cancel/page.tsx
@@ -1,8 +1,105 @@
-export default function PlaceholderPage() {
+import Link from 'next/link';
+import { auth } from '@clerk/nextjs/server';
+import {
+  getOrderDisplayById,
+  OrderDisplayItem,
+  orderStatusLabels
+} from '@/lib/order-display';
+import { formatMoneyFromCents } from '@/lib/money';
+import prisma from '@/lib/prisma';
+
+type PaymentCancelProps = {
+  searchParams: Promise<{
+    order_id?: string | string[];
+  }>;
+};
+
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+async function getCancelledOrder(orderId: string | undefined) {
+  if (!orderId) return null;
+
+  const { userId: clerkUserId } = await auth();
+  if (!clerkUserId) return null;
+
+  const currentUser = await prisma.user.findUnique({
+    where: { clerkId: clerkUserId },
+    select: { id: true }
+  });
+
+  if (!currentUser) return null;
+
+  return getOrderDisplayById(orderId, currentUser.id);
+}
+
+function ItemSummary({ item }: { item: OrderDisplayItem }) {
   return (
-    <div className="p-4 text-gray-500">
-      <h1 className="text-lg font-semibold">🚧 Page Under Construction</h1>
-      <p>This page is currently being set up.</p>
-    </div>
+    <li className="flex justify-between gap-4 text-pace-base text-pace-gray-700">
+      <span>
+        {item.typeLabel} · {item.title}
+      </span>
+      <span>{formatMoneyFromCents(item.priceCents)}</span>
+    </li>
+  );
+}
+
+export default async function PaymentCancel({
+  searchParams
+}: PaymentCancelProps) {
+  const params = await searchParams;
+  const orderId = firstParam(params.order_id);
+  const order = await getCancelledOrder(orderId);
+
+  return (
+    <section className="mx-auto flex min-h-[520px] max-w-[720px] flex-col items-center justify-center px-6 py-20 text-center">
+      <h1 className="text-[28px] font-bold text-pace-gray-700">
+        결제가 완료되지 않았습니다.
+      </h1>
+      <p className="mt-4 text-pace-base text-pace-stone-500">
+        Stripe Checkout이 취소되었습니다. 장바구니에서 다시 결제를 진행할 수
+        있습니다.
+      </p>
+
+      {order && (
+        <div className="mt-10 w-full rounded-lg border border-pace-gray-100 p-6 text-left">
+          <div className="flex justify-between text-pace-base text-pace-stone-500">
+            <span>주문번호</span>
+            <span>{order.orderNumber}</span>
+          </div>
+          <div className="mt-2 flex justify-between text-pace-base text-pace-stone-500">
+            <span>주문상태</span>
+            <span>{orderStatusLabels[order.status]}</span>
+          </div>
+          <ul className="mt-6 space-y-2 border-t border-pace-gray-100 pt-6">
+            {order.items.map((item) => (
+              <ItemSummary key={item.id} item={item} />
+            ))}
+          </ul>
+          <div className="mt-6 flex justify-between border-t border-pace-gray-100 pt-6 text-[20px] font-semibold text-pace-gray-700">
+            <span>총 결제 금액</span>
+            <span>
+              {formatMoneyFromCents(order.totalAmountCents, order.currency)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-10 flex gap-4">
+        <Link
+          href="/mypage/cart"
+          className="bg-pace-orange-800 px-10 py-4 rounded-full text-pace-white-500 hover:bg-pace-orange-600"
+        >
+          장바구니로 돌아가기
+        </Link>
+        <Link
+          href="/"
+          className="border-2 border-pace-orange-600 px-10 py-4 rounded-full text-pace-orange-600 hover:bg-pace-ivory-500"
+        >
+          홈으로 가기
+        </Link>
+      </div>
+    </section>
   );
 }

--- a/src/app/payment/success/page.tsx
+++ b/src/app/payment/success/page.tsx
@@ -1,127 +1,25 @@
-import Image from 'next/image';
-import { CustomBadge } from '@/components/common/custom-badge';
-import { CartItem } from '@/types/my-card';
-import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
-const items: CartItem[] = [
-  {
-    id: '1',
-    itemId: '4e8wv1z7tl',
-    title: 'UX Design Fundamentals',
-    price: 2800,
-    category: 'Marketing',
-    type: '전자책'
-  },
-  {
-    id: '2',
-    itemId: '4e8wv1z7tl',
-    title: 'UX Design Fundamentals',
-    price: 15.99,
-    category: 'Interview',
-    type: '온라인 강의'
-  },
-  {
-    id: '3',
-    itemId: '4e8wv1z7tl',
-    title: '성공을 부르는 마인드 트레이닝',
-    price: 20,
-    category: '',
-    date: new Date('2025-05-10'),
-    type: '워크샵'
-  },
-  {
-    id: '4',
-    itemId: '4e8wv1z7tl',
-    title: 'Test3',
-    price: 9.57,
-    category: 'Resume',
-    type: '온라인 강의'
+type PaymentSuccessAliasProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function PaymentSuccessAlias({
+  searchParams
+}: PaymentSuccessAliasProps) {
+  const params = await searchParams;
+  const redirectParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      value.forEach((item) => redirectParams.append(key, item));
+    } else if (value) {
+      redirectParams.set(key, value);
+    }
   }
-];
 
-export default function PaymentSuccess() {
-  const paymentNumber = 'AA0000';
-  return (
-    <section className="flex-1 p-10 pt-20">
-      <h1 className="text-pace-xl font-bold mb-6 text-pace-gray-700">
-        장바구니
-      </h1>
-      <div className="flex flex-col gap-4 mb-20 items-center justify-center text-center">
-        <Image
-          src="/icons/check-icon.svg"
-          alt="check icon"
-          width={32}
-          height={32}
-        />
-        <h1 className="text-[20px] font-medium text-pace-gray-700">결제완료</h1>
-        <p className="text-pace-stone-500">
-          결제가 완료되었습니다.
-          <br />
-          결제번호는 <span className="font-semibold">{paymentNumber}</span>{' '}
-          입니다.
-        </p>
-
-        <div className="flex mt-2 gap-4">
-          <Link
-            href="/mypage"
-            className="bg-pace-orange-800 px-10 py-4 rounded-full text-pace-white-500 hover:bg-pace-orange-600"
-          >
-            강의 현황 보러가기
-          </Link>
-          <Link
-            href="/purchase"
-            className="border-2 border-pace-orange-600 px-10 py-4 rounded-full text-pace-orange-600 hover:bg-pace-ivory-500"
-          >
-            구매내역 보러가기
-          </Link>
-        </div>
-      </div>
-
-      <div className="space-y-4 text-[20px] text-pace-gray-500">
-        {items.map((item) => (
-          <div key={item.id} className="flex items-center border-t p-4 !m-0">
-            <div className="w-20 h-4 text-pace-sm text-center text-pace-stone-500 mx-6">
-              {item.type}
-            </div>
-            <Image
-              src="/img/resume_lecture.jpeg"
-              alt={item.title}
-              width={160}
-              height={106}
-              className="w-40 h-[106px] rounded-lg object-cover"
-            />
-            <div className="ml-6">
-              {item.category && (
-                <CustomBadge
-                  variant={item.category}
-                  className="w-fit flex justify-center items-center py-2 px-3"
-                >
-                  {item.category}
-                </CustomBadge>
-              )}
-              {item.date && (
-                <div className="text-pace-sm">
-                  {item.date && (
-                    <div className="text-pace-sm">
-                      {item.date.toISOString().slice(0, 10).replace(/-/g, '.')}
-                    </div>
-                  )}
-                </div>
-              )}
-
-              <div className="mt-2">{item.title}</div>
-            </div>
-            <Link
-              href="/purchase"
-              className="w-[120px] p-4 text-center ml-auto bg-pace-orange-500 rounded-full text-pace-base text-pace-white-500 font-regular"
-            >
-              {item.type === '워크샵' ? 'View detail' : '수강하러 가기'}
-            </Link>
-
-            <button className=""></button>
-          </div>
-        ))}
-      </div>
-    </section>
+  const query = redirectParams.toString();
+  redirect(
+    query ? `/mypage/payment-success?${query}` : '/mypage/payment-success'
   );
 }

--- a/src/components/features/mypage/cart/payment-summary.test.tsx
+++ b/src/components/features/mypage/cart/payment-summary.test.tsx
@@ -96,6 +96,18 @@ describe('PaymentSummary', () => {
     ).toBeDisabled();
   });
 
+  it('shows CAD amounts without inactive promotion controls', () => {
+    render(<PaymentSummary cartItems={cartItems} />);
+
+    expect(screen.getAllByText('CA$49.99').length).toBeGreaterThan(0);
+    expect(
+      screen.queryByPlaceholderText('프로모션 코드 입력')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: '등록' })
+    ).not.toBeInTheDocument();
+  });
+
   it('shows API errors without redirecting', async () => {
     (fetch as unknown as Mock).mockResolvedValue({
       ok: false,

--- a/src/components/features/mypage/cart/payment-summary.test.tsx
+++ b/src/components/features/mypage/cart/payment-summary.test.tsx
@@ -5,12 +5,14 @@ import type { CartItem } from '@/types/my-card';
 import PaymentSummary from './payment-summary';
 
 const mocks = vi.hoisted(() => ({
-  toastErrorMock: vi.fn()
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn()
 }));
 
 vi.mock('sonner', () => ({
   toast: {
-    error: mocks.toastErrorMock
+    error: mocks.toastErrorMock,
+    success: mocks.toastSuccessMock
   }
 }));
 
@@ -96,16 +98,103 @@ describe('PaymentSummary', () => {
     ).toBeDisabled();
   });
 
-  it('shows CAD amounts without inactive promotion controls', () => {
+  it('shows CAD amounts and promotion controls', () => {
     render(<PaymentSummary cartItems={cartItems} />);
 
     expect(screen.getAllByText('CA$49.99').length).toBeGreaterThan(0);
     expect(
-      screen.queryByPlaceholderText('프로모션 코드 입력')
-    ).not.toBeInTheDocument();
+      screen.getAllByPlaceholderText('프로모션 코드 입력').length
+    ).toBeGreaterThan(0);
     expect(
-      screen.queryByRole('button', { name: '등록' })
-    ).not.toBeInTheDocument();
+      screen.getAllByRole('button', { name: '등록' }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('validates and submits applied promotion codes', async () => {
+    (fetch as unknown as Mock)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          promotionCode: {
+            code: 'SAVE10'
+          }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          checkoutUrl: 'https://checkout.stripe.test/session'
+        })
+      });
+
+    render(<PaymentSummary cartItems={cartItems} />);
+
+    fireEvent.change(screen.getAllByPlaceholderText('프로모션 코드 입력')[0], {
+      target: { value: 'SAVE10' }
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: '등록' })[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenNthCalledWith(
+        1,
+        '/api/stripe/validate-promotion-code',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            selectedItems: [
+              {
+                itemId: '11111111-1111-4111-8111-111111111111',
+                itemType: 'COURSE'
+              }
+            ],
+            promotionCode: 'SAVE10'
+          })
+        })
+      );
+    });
+    expect(await screen.findAllByText('적용된 코드: SAVE10')).toHaveLength(1);
+    expect(mocks.toastSuccessMock).toHaveBeenCalledWith(
+      '프로모션 코드가 적용되었습니다.'
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenNthCalledWith(
+        2,
+        '/api/stripe/create-checkout-session',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            selectedItems: [
+              {
+                itemId: '11111111-1111-4111-8111-111111111111',
+                itemType: 'COURSE'
+              }
+            ],
+            promotionCode: 'SAVE10'
+          })
+        })
+      );
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith(
+      'https://checkout.stripe.test/session'
+    );
+  });
+
+  it('requires typed promotion codes to be registered before checkout', () => {
+    render(<PaymentSummary cartItems={cartItems} />);
+
+    fireEvent.change(screen.getAllByPlaceholderText('프로모션 코드 입력')[0], {
+      target: { value: 'SAVE10' }
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
+
+    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
+      '프로모션 코드를 먼저 등록해주세요.'
+    );
+    expect(fetch).not.toHaveBeenCalled();
+    expect(locationAssignMock).not.toHaveBeenCalled();
   });
 
   it('shows API errors without redirecting', async () => {

--- a/src/components/features/mypage/cart/payment-summary.test.tsx
+++ b/src/components/features/mypage/cart/payment-summary.test.tsx
@@ -153,6 +153,14 @@ describe('PaymentSummary', () => {
       );
     });
     expect(await screen.findAllByText('적용된 코드: SAVE10')).toHaveLength(1);
+    expect(
+      screen.getAllByText('Stripe Checkout에서 적용').length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        '프로모션 할인은 Stripe Checkout에서 최종 반영됩니다.'
+      ).length
+    ).toBeGreaterThan(0);
     expect(mocks.toastSuccessMock).toHaveBeenCalledWith(
       '프로모션 코드가 적용되었습니다.'
     );

--- a/src/components/features/mypage/cart/payment-summary.test.tsx
+++ b/src/components/features/mypage/cart/payment-summary.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import type { CartItem } from '@/types/my-card';
+import PaymentSummary from './payment-summary';
+
+const mocks = vi.hoisted(() => ({
+  toastErrorMock: vi.fn()
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastErrorMock
+  }
+}));
+
+const cartItems: CartItem[] = [
+  {
+    id: 'cart-1',
+    itemId: '11111111-1111-4111-8111-111111111111',
+    title: 'Checkout Course',
+    category: 'INTERVIEW',
+    price: 49.99,
+    type: 'COURSE',
+    selected: true
+  },
+  {
+    id: 'cart-2',
+    itemId: '22222222-2222-4222-8222-222222222222',
+    title: 'Unselected Ebook',
+    category: 'MARKETING',
+    price: 12.5,
+    type: 'EBOOK',
+    selected: false
+  }
+];
+
+describe('PaymentSummary', () => {
+  const locationAssignMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        assign: locationAssignMock
+      }
+    });
+  });
+
+  it('starts Stripe checkout with selected cart items only', async () => {
+    (fetch as unknown as Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        checkoutUrl: 'https://checkout.stripe.test/session'
+      })
+    });
+
+    render(<PaymentSummary cartItems={cartItems} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/stripe/create-checkout-session',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            selectedItems: [
+              {
+                itemId: '11111111-1111-4111-8111-111111111111',
+                itemType: 'COURSE'
+              }
+            ]
+          })
+        })
+      );
+    });
+    expect(locationAssignMock).toHaveBeenCalledWith(
+      'https://checkout.stripe.test/session'
+    );
+  });
+
+  it('disables checkout when no cart items are selected', () => {
+    render(
+      <PaymentSummary
+        cartItems={cartItems.map((item) => ({ ...item, selected: false }))}
+      />
+    );
+
+    expect(
+      screen.getAllByRole('button', { name: '결제하기' })[0]
+    ).toBeDisabled();
+  });
+
+  it('shows API errors without redirecting', async () => {
+    (fetch as unknown as Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        error: 'Already purchased: Checkout Course'
+      })
+    });
+
+    render(<PaymentSummary cartItems={cartItems} />);
+
+    fireEvent.click(screen.getAllByRole('button', { name: '결제하기' })[0]);
+
+    expect(
+      await screen.findAllByText('Already purchased: Checkout Course')
+    ).toHaveLength(2);
+    expect(mocks.toastErrorMock).toHaveBeenCalledWith(
+      'Already purchased: Checkout Course'
+    );
+    expect(locationAssignMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/features/mypage/cart/payment-summary.tsx
+++ b/src/components/features/mypage/cart/payment-summary.tsx
@@ -14,9 +14,18 @@ interface PaymentSummaryProps {
 export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
   const [showDetails, setShowDetails] = useState(false);
   const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const [isApplyingPromotionCode, setIsApplyingPromotionCode] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  const [promotionCodeInput, setPromotionCodeInput] = useState('');
+  const [appliedPromotionCode, setAppliedPromotionCode] = useState<
+    string | null
+  >(null);
 
   const selectedItem = cartItems.filter((item) => item.selected);
+  const selectedItemsPayload = selectedItem.map((item) => ({
+    itemId: item.itemId,
+    itemType: item.type
+  }));
   const subtotal = selectedItem.reduce(
     (acc, item) => acc + (Number(item.price) || 0),
     0
@@ -28,10 +37,82 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
   const isCheckoutDisabled = selectedItem.length === 0 || isCheckingOut;
   const formatCartAmount = (cents: number) =>
     formatMoneyFromCents(cents, 'cad', 'en-US');
+  const trimmedPromotionCode = promotionCodeInput.trim();
+  const discountDisplay = appliedPromotionCode
+    ? 'Stripe에서 계산'
+    : `-${formatCartAmount(discountCents)}`;
+
+  const handlePromotionCodeChange = (value: string) => {
+    setPromotionCodeInput(value);
+
+    if (
+      appliedPromotionCode &&
+      value.trim().toLowerCase() !== appliedPromotionCode.toLowerCase()
+    ) {
+      setAppliedPromotionCode(null);
+    }
+  };
+
+  const applyPromotionCode = async () => {
+    if (selectedItem.length === 0) {
+      const message = '결제할 항목을 선택해주세요.';
+      setCheckoutError(message);
+      toast.error(message);
+      return;
+    }
+
+    if (!trimmedPromotionCode) {
+      const message = '프로모션 코드를 입력해주세요.';
+      setCheckoutError(message);
+      toast.error(message);
+      return;
+    }
+
+    setIsApplyingPromotionCode(true);
+    setCheckoutError(null);
+
+    try {
+      const response = await fetch('/api/stripe/validate-promotion-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectedItems: selectedItemsPayload,
+          promotionCode: trimmedPromotionCode
+        })
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.promotionCode?.code) {
+        throw new Error(data.error || '프로모션 코드를 적용하지 못했습니다.');
+      }
+
+      setAppliedPromotionCode(data.promotionCode.code);
+      setPromotionCodeInput(data.promotionCode.code);
+      toast.success('프로모션 코드가 적용되었습니다.');
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '프로모션 코드를 적용하지 못했습니다.';
+
+      setAppliedPromotionCode(null);
+      setCheckoutError(message);
+      toast.error(message);
+    } finally {
+      setIsApplyingPromotionCode(false);
+    }
+  };
 
   const startCheckout = async () => {
     if (selectedItem.length === 0) {
       const message = '결제할 항목을 선택해주세요.';
+      setCheckoutError(message);
+      toast.error(message);
+      return;
+    }
+
+    if (trimmedPromotionCode && !appliedPromotionCode) {
+      const message = '프로모션 코드를 먼저 등록해주세요.';
       setCheckoutError(message);
       toast.error(message);
       return;
@@ -45,10 +126,10 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          selectedItems: selectedItem.map((item) => ({
-            itemId: item.itemId,
-            itemType: item.type
-          }))
+          selectedItems: selectedItemsPayload,
+          ...(appliedPromotionCode
+            ? { promotionCode: appliedPromotionCode }
+            : {})
         })
       });
       const data = await response.json();
@@ -71,6 +152,41 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
     }
   };
 
+  const renderPromotionControls = (className = '') => (
+    <div className={className}>
+      <div className="flex gap-1 text-pace-sm">
+        <input
+          type="text"
+          value={promotionCodeInput}
+          onChange={(event) => handlePromotionCodeChange(event.target.value)}
+          placeholder="프로모션 코드 입력"
+          className="min-w-0 flex-1 rounded-full border border-[#EEEEEE] px-4 py-2 placeholder-[#757575] focus:border-[#6F6F6F] focus:outline-none"
+        />
+        <button
+          type="button"
+          className="shrink-0 rounded-full border border-[#EEEEEE] px-4 py-2 text-pace-gray-700 hover:border-[#6F6F6F] disabled:cursor-not-allowed disabled:text-pace-stone-500 disabled:hover:border-[#EEEEEE]"
+          onClick={applyPromotionCode}
+          disabled={
+            isApplyingPromotionCode ||
+            selectedItem.length === 0 ||
+            !trimmedPromotionCode
+          }
+        >
+          {isApplyingPromotionCode
+            ? '확인 중...'
+            : appliedPromotionCode
+              ? '변경'
+              : '등록'}
+        </button>
+      </div>
+      {appliedPromotionCode && (
+        <p className="mt-2 text-pace-sm text-pace-orange-600">
+          적용된 코드: {appliedPromotionCode}
+        </p>
+      )}
+    </div>
+  );
+
   return (
     <>
       <aside className="hidden lg:block w-80 h-full border-l p-10 pt-20">
@@ -84,7 +200,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
           </li>
           <li className="flex justify-between">
             <span className="text-[#6B7280]">할인 금액</span>
-            <span>-{formatCartAmount(discountCents)}</span>
+            <span>{discountDisplay}</span>
           </li>
           <li className="flex justify-between">
             <span className="text-[#6B7280]">세금</span>
@@ -97,6 +213,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
             {formatCartAmount(totalCents)}
           </span>
         </div>
+        {renderPromotionControls('mb-4')}
         <button
           className="w-full h-[56px] bg-orange-500 text-white py-2 rounded-full disabled:cursor-not-allowed disabled:bg-pace-stone-300"
           onClick={startCheckout}
@@ -151,13 +268,14 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
                 </li>
                 <li className="flex justify-between">
                   <span className="text-[#6B7280]">할인 금액</span>
-                  <span>-{formatCartAmount(discountCents)}</span>
+                  <span>{discountDisplay}</span>
                 </li>
                 <li className="flex justify-between">
                   <span className="text-[#6B7280]">세금</span>
                   <span>{formatCartAmount(taxCents)}</span>
                 </li>
               </ul>
+              {renderPromotionControls('my-6 ml-auto w-60')}
               <div className="mt-4 border-b border-pace-gray-700" />
             </div>
           )}

--- a/src/components/features/mypage/cart/payment-summary.tsx
+++ b/src/components/features/mypage/cart/payment-summary.tsx
@@ -1,29 +1,72 @@
+'use client';
+
 import Image from 'next/image';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { CartItem } from '@/types/my-card';
-import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 interface PaymentSummaryProps {
   cartItems: CartItem[];
 }
 
 export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
-  const router = useRouter();
   const [showDetails, setShowDetails] = useState(false);
+  const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const [checkoutError, setCheckoutError] = useState<string | null>(null);
 
   const selectedItem = cartItems.filter((item) => item.selected);
   const subtotal = selectedItem.reduce(
     (acc, item) => acc + (Number(item.price) || 0),
     0
   );
-  const discount = 20;
-  const tax = subtotal * 0.13;
+  const discount = 0;
+  const tax = 0;
   const total = subtotal - discount + tax;
+  const isCheckoutDisabled = selectedItem.length === 0 || isCheckingOut;
 
-  const goToPaymentSuccess = () => {
-    router.push('/mypage/payment-success');
+  const startCheckout = async () => {
+    if (selectedItem.length === 0) {
+      const message = '결제할 항목을 선택해주세요.';
+      setCheckoutError(message);
+      toast.error(message);
+      return;
+    }
+
+    setIsCheckingOut(true);
+    setCheckoutError(null);
+
+    try {
+      const response = await fetch('/api/stripe/create-checkout-session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          selectedItems: selectedItem.map((item) => ({
+            itemId: item.itemId,
+            itemType: item.type
+          }))
+        })
+      });
+      const data = await response.json();
+
+      if (!response.ok || !data.checkoutUrl) {
+        throw new Error(data.error || '체크아웃을 시작하지 못했습니다.');
+      }
+
+      window.location.assign(data.checkoutUrl);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : '체크아웃을 시작하지 못했습니다.';
+
+      setCheckoutError(message);
+      toast.error(message);
+    } finally {
+      setIsCheckingOut(false);
+    }
   };
+
   return (
     <>
       <aside className="hidden lg:block w-80 h-full border-l p-10 pt-20">
@@ -31,7 +74,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
         <ul className="space-y-4 mb-6 font-normal border-b border-pace-gray-700 pb-6 text-pace-base text-pace-gray-700">
           <li className="flex justify-between">
             <span className="text-[#6B7280]">
-              소계 ({selectedItem.length}개의 강의)
+              소계 ({selectedItem.length}개 항목)
             </span>
             <span>${subtotal.toFixed(2)}</span>
           </li>
@@ -57,11 +100,15 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
           등록
         </button>
         <button
-          className="w-full h-[56px] bg-orange-500 text-white py-2 mt-6 rounded-full"
-          onClick={goToPaymentSuccess}
+          className="w-full h-[56px] bg-orange-500 text-white py-2 mt-6 rounded-full disabled:cursor-not-allowed disabled:bg-pace-stone-300"
+          onClick={startCheckout}
+          disabled={isCheckoutDisabled}
         >
-          결제하기
+          {isCheckingOut ? '처리 중...' : '결제하기'}
         </button>
+        {checkoutError && (
+          <p className="mt-3 text-pace-sm text-red-600">{checkoutError}</p>
+        )}
         <div className="flex justify-center mt-6 text-pace-stone-700 text-[12px]">
           Secure payment powered by Stripe
         </div>
@@ -100,7 +147,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
               <ul className="space-y-4 font-normal text-pace-base text-pace-gray-700">
                 <li className="flex justify-between">
                   <span className="text-[#6B7280]">
-                    소계 ({selectedItem.length}개의 강의)
+                    소계 ({selectedItem.length}개 항목)
                   </span>
                   <span>${subtotal.toFixed(2)}</span>
                 </li>
@@ -136,13 +183,19 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
                 ${total.toFixed(2)}
               </span>
               <button
-                className="w-60 h-[56px] bg-orange-500 text-white px-4 py-2 rounded-full text-pace-lg"
-                onClick={goToPaymentSuccess}
+                className="w-60 h-[56px] bg-orange-500 text-white px-4 py-2 rounded-full text-pace-lg disabled:cursor-not-allowed disabled:bg-pace-stone-300"
+                onClick={startCheckout}
+                disabled={isCheckoutDisabled}
               >
-                결제하기
+                {isCheckingOut ? '처리 중...' : '결제하기'}
               </button>
             </div>
           </div>
+          {checkoutError && (
+            <p className="mt-3 w-2/3 text-right text-pace-sm text-red-600">
+              {checkoutError}
+            </p>
+          )}
         </div>
       </aside>
     </>

--- a/src/components/features/mypage/cart/payment-summary.tsx
+++ b/src/components/features/mypage/cart/payment-summary.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { CartItem } from '@/types/my-card';
+import { amountToCents, formatMoneyFromCents } from '@/lib/money';
 import { toast } from 'sonner';
 
 interface PaymentSummaryProps {
@@ -20,10 +21,13 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
     (acc, item) => acc + (Number(item.price) || 0),
     0
   );
-  const discount = 0;
-  const tax = 0;
-  const total = subtotal - discount + tax;
+  const subtotalCents = amountToCents(subtotal);
+  const discountCents = 0;
+  const taxCents = 0;
+  const totalCents = subtotalCents - discountCents + taxCents;
   const isCheckoutDisabled = selectedItem.length === 0 || isCheckingOut;
+  const formatCartAmount = (cents: number) =>
+    formatMoneyFromCents(cents, 'cad', 'en-US');
 
   const startCheckout = async () => {
     if (selectedItem.length === 0) {
@@ -76,31 +80,25 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
             <span className="text-[#6B7280]">
               소계 ({selectedItem.length}개 항목)
             </span>
-            <span>${subtotal.toFixed(2)}</span>
+            <span>{formatCartAmount(subtotalCents)}</span>
           </li>
           <li className="flex justify-between">
             <span className="text-[#6B7280]">할인 금액</span>
-            <span>-${discount.toFixed(2)}</span>
+            <span>-{formatCartAmount(discountCents)}</span>
           </li>
           <li className="flex justify-between">
             <span className="text-[#6B7280]">세금</span>
-            <span>${tax.toFixed(2)}</span>
+            <span>{formatCartAmount(taxCents)}</span>
           </li>
         </ul>
         <div className="flex justify-between text-pace-base font-semibold pb-6">
           <span className="text-pace-gray-700">총 결제 금액</span>
-          <span className="text-[#E86642] font-bold">${total.toFixed(2)}</span>
+          <span className="text-[#E86642] font-bold">
+            {formatCartAmount(totalCents)}
+          </span>
         </div>
-        <input
-          type="text"
-          placeholder="프로모션 코드 입력"
-          className="w-full flex-1 mb-1 px-4 py-2 placeholder-[#757575] rounded-full border border-[#EEEEEE] focus:border-[#6F6F6F] focus:outline-none"
-        />
-        <button className="w-full px-4 py-2 text-pace-gray-700 rounded-full border border-[#EEEEEE] hover:border-[#6F6F6F]">
-          등록
-        </button>
         <button
-          className="w-full h-[56px] bg-orange-500 text-white py-2 mt-6 rounded-full disabled:cursor-not-allowed disabled:bg-pace-stone-300"
+          className="w-full h-[56px] bg-orange-500 text-white py-2 rounded-full disabled:cursor-not-allowed disabled:bg-pace-stone-300"
           onClick={startCheckout}
           disabled={isCheckoutDisabled}
         >
@@ -149,29 +147,18 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
                   <span className="text-[#6B7280]">
                     소계 ({selectedItem.length}개 항목)
                   </span>
-                  <span>${subtotal.toFixed(2)}</span>
+                  <span>{formatCartAmount(subtotalCents)}</span>
                 </li>
                 <li className="flex justify-between">
                   <span className="text-[#6B7280]">할인 금액</span>
-                  <span>-${discount.toFixed(2)}</span>
+                  <span>-{formatCartAmount(discountCents)}</span>
                 </li>
                 <li className="flex justify-between">
                   <span className="text-[#6B7280]">세금</span>
-                  <span>${tax.toFixed(2)}</span>
+                  <span>{formatCartAmount(taxCents)}</span>
                 </li>
               </ul>
-              <div className="border-b border-pace-gray-700 mb-4">
-                <div className="w-60 h-[37px] flex gap-1 my-6 text-pace-sm ml-auto">
-                  <input
-                    type="text"
-                    placeholder="프로모션 코드 입력"
-                    className="flex-1 min-w-0 px-4 py-2 placeholder-[#757575] rounded-full border border-[#EEEEEE] focus:border-[#6F6F6F] focus:outline-none"
-                  />
-                  <button className="px-4 py-2 text-pace-gray-700 rounded-full border border-[#EEEEEE] hover:border-[#6F6F6F]">
-                    등록
-                  </button>
-                </div>
-              </div>
+              <div className="mt-4 border-b border-pace-gray-700" />
             </div>
           )}
 
@@ -180,7 +167,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
             <span className="font-medium">총 결제 금액</span>
             <div className="flex items-center gap-4">
               <span className="text-[#E86642] font-bold">
-                ${total.toFixed(2)}
+                {formatCartAmount(totalCents)}
               </span>
               <button
                 className="w-60 h-[56px] bg-orange-500 text-white px-4 py-2 rounded-full text-pace-lg disabled:cursor-not-allowed disabled:bg-pace-stone-300"

--- a/src/components/features/mypage/cart/payment-summary.tsx
+++ b/src/components/features/mypage/cart/payment-summary.tsx
@@ -39,8 +39,11 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
     formatMoneyFromCents(cents, 'cad', 'en-US');
   const trimmedPromotionCode = promotionCodeInput.trim();
   const discountDisplay = appliedPromotionCode
-    ? 'Stripe에서 계산'
+    ? 'Stripe Checkout에서 적용'
     : `-${formatCartAmount(discountCents)}`;
+  const totalLabel = appliedPromotionCode
+    ? '할인 전 예상 금액'
+    : '총 결제 금액';
 
   const handlePromotionCodeChange = (value: string) => {
     setPromotionCodeInput(value);
@@ -208,11 +211,16 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
           </li>
         </ul>
         <div className="flex justify-between text-pace-base font-semibold pb-6">
-          <span className="text-pace-gray-700">총 결제 금액</span>
+          <span className="text-pace-gray-700">{totalLabel}</span>
           <span className="text-[#E86642] font-bold">
             {formatCartAmount(totalCents)}
           </span>
         </div>
+        {appliedPromotionCode && (
+          <p className="-mt-4 mb-4 text-pace-sm text-pace-stone-500">
+            프로모션 할인은 Stripe Checkout에서 최종 반영됩니다.
+          </p>
+        )}
         {renderPromotionControls('mb-4')}
         <button
           className="w-full h-[56px] bg-orange-500 text-white py-2 rounded-full disabled:cursor-not-allowed disabled:bg-pace-stone-300"
@@ -282,7 +290,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
 
           {/* 총 금액 & 결제 버튼 */}
           <div className="w-2/3 flex justify-between items-center text-pace-xl">
-            <span className="font-medium">총 결제 금액</span>
+            <span className="font-medium">{totalLabel}</span>
             <div className="flex items-center gap-4">
               <span className="text-[#E86642] font-bold">
                 {formatCartAmount(totalCents)}
@@ -296,6 +304,11 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
               </button>
             </div>
           </div>
+          {appliedPromotionCode && (
+            <p className="mt-3 w-2/3 text-right text-pace-sm text-pace-stone-500">
+              프로모션 할인은 Stripe Checkout에서 최종 반영됩니다.
+            </p>
+          )}
           {checkoutError && (
             <p className="mt-3 w-2/3 text-right text-pace-sm text-red-600">
               {checkoutError}

--- a/src/components/features/mypage/purchases/purchase-details-popup.tsx
+++ b/src/components/features/mypage/purchases/purchase-details-popup.tsx
@@ -8,37 +8,25 @@ import {
   DialogTitle,
   DialogTrigger
 } from '@/components/ui/dialog';
+import { formatMoneyFromCents } from '@/lib/money';
 import RefundPopup from './refund-popup';
 import SaveReceiptPopup from './save-receipt-popup';
-
-type PurchaseItem = {
-  type: string;
-  title: string;
-  price: number;
-};
-
-type PaymentInfo = {
-  subtotal: number;
-  discount: number;
-  tax: number;
-  method: string;
-  installment: string;
-  card: string;
-  total: number;
-};
+import type { PurchaseListItem, PurchasePaymentInfo } from './purchases-list';
 
 type DetailPopupProps = {
   orderNumber: string;
   date: string;
-  items: PurchaseItem[];
-  payment: PaymentInfo;
+  items: PurchaseListItem[];
+  payment: PurchasePaymentInfo;
+  receiptUrl: string | null;
 };
 
 export default function PurchaseDetailsPopup({
   orderNumber,
   date,
   items,
-  payment
+  payment,
+  receiptUrl
 }: DetailPopupProps) {
   const [isRefundPopupOpen, setIsRefundPopupOpen] = useState(false);
   const [isReceiptPopupOpen, setIsReceiptPopupOpen] = useState(false);
@@ -72,11 +60,13 @@ export default function PurchaseDetailsPopup({
               구매강의 리스트
             </h3>
             <ul className="space-y-2 pb-6 border-b border-pace-gray-700">
-              {items.map((item, idx) => (
-                <li key={idx} className="grid grid-cols-[80px_1fr_auto]">
+              {items.map((item) => (
+                <li key={item.id} className="grid grid-cols-[80px_1fr_auto]">
                   <span>{item.type}</span>
                   <span>{item.title}</span>
-                  <span className="text-right">${item.price.toFixed(2)}</span>
+                  <span className="text-right">
+                    {formatMoneyFromCents(item.priceCents, payment.currency)}
+                  </span>
                 </li>
               ))}
             </ul>
@@ -89,15 +79,27 @@ export default function PurchaseDetailsPopup({
             <div className="space-y-2 pb-6 mb-6 border-b border-pace-gray-200">
               <div className="flex justify-between">
                 <span>소계</span>
-                <span>${payment.subtotal.toFixed(2)}</span>
+                <span>
+                  {formatMoneyFromCents(
+                    payment.subtotalCents,
+                    payment.currency
+                  )}
+                </span>
               </div>
               <div className="flex justify-between">
                 <span>할인금액</span>
-                <span>${payment.discount.toFixed(2)}</span>
+                <span>
+                  {formatMoneyFromCents(
+                    payment.discountCents,
+                    payment.currency
+                  )}
+                </span>
               </div>
               <div className="flex justify-between mb-4">
                 <span>세금</span>
-                <span>${payment.tax.toFixed(2)}</span>
+                <span>
+                  {formatMoneyFromCents(payment.taxCents, payment.currency)}
+                </span>
               </div>
             </div>
             <div>
@@ -118,7 +120,9 @@ export default function PurchaseDetailsPopup({
 
           <div className="flex justify-between items-center font-medium text-[20px] text-pace-gray-500">
             <span>총 결제 금액</span>
-            <span>${payment.total.toFixed(2)}</span>
+            <span>
+              {formatMoneyFromCents(payment.totalCents, payment.currency)}
+            </span>
           </div>
         </div>
 
@@ -126,6 +130,7 @@ export default function PurchaseDetailsPopup({
           <SaveReceiptPopup
             open={isReceiptPopupOpen}
             onOpenChange={setIsReceiptPopupOpen}
+            receiptUrl={receiptUrl}
           />
           <RefundPopup
             open={isRefundPopupOpen}

--- a/src/components/features/mypage/purchases/purchases-list.tsx
+++ b/src/components/features/mypage/purchases/purchases-list.tsx
@@ -2,64 +2,58 @@
 
 import Image from 'next/image';
 import { useState } from 'react';
+import type { OrderStatus } from '@prisma/client';
+import { formatMoneyFromCents } from '@/lib/money';
 import PurchaseDetailsPopup from './purchase-details-popup';
+
+export type PurchaseListItem = {
+  id: string;
+  type: string;
+  title: string;
+  priceCents: number;
+  quantity: number;
+};
+
+export type PurchasePaymentInfo = {
+  subtotalCents: number;
+  discountCents: number;
+  taxCents: number;
+  method: string;
+  installment: string;
+  card: string;
+  totalCents: number;
+  currency: string;
+};
 
 type PurchasesListProps = {
   orderNumber: string;
-  items: string[];
-  amount: number;
-  status: string;
-  date: Date;
+  items: PurchaseListItem[];
+  amountCents: number;
+  status: OrderStatus;
+  statusLabel: string;
+  date: string;
+  currency: string;
+  payment: PurchasePaymentInfo;
+  receiptUrl: string | null;
   isFirst: boolean;
 };
 
 export default function PurchasesList({
   orderNumber,
   items,
-  amount,
+  amountCents,
   status,
+  statusLabel,
   date,
+  currency,
+  payment,
+  receiptUrl,
   isFirst
 }: PurchasesListProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const isRefunded = status === '환불완료';
+  const isRefunded = status === 'REFUNDED';
   const textColorClass = isRefunded ? 'text-pace-stone-800' : '';
-
-  const orderDetailData = {
-    orderNumber: 'No.ABCD123456',
-    date: '2025-05-30',
-    items: [
-      {
-        type: '온라인 강의',
-        title: '자기소개서 작성 및 면접 준비까지 하나로!',
-        price: 99.99
-      },
-      {
-        type: '전자책',
-        title: '자기소개서 작성 및 면접 준비까지 하나로!',
-        price: 99.99
-      },
-      {
-        type: '워크샵',
-        title: '자기소개서 작성 및 면접 준비까지 하나로!',
-        price: 99.99
-      },
-      {
-        type: '온라인 강의',
-        title: '자기소개서 작성 및 면접 준비까지 하나로!',
-        price: 99.99
-      }
-    ],
-    payment: {
-      subtotal: 99.99,
-      discount: 99.99,
-      tax: 99.99,
-      method: '신용카드',
-      installment: '일시불',
-      card: 'visa 000 0000 000',
-      total: 999.99
-    }
-  };
+  const firstTitle = items[0]?.title ?? '구매 항목';
 
   return (
     <div className={`border-b pt-6 pb-8 ${isFirst ? 'border-t' : ''}`}>
@@ -68,14 +62,14 @@ export default function PurchasesList({
           <div
             className={`text-pace-sm font-light space-x-4 text-pace-stone-500 ${textColorClass}`}
           >
-            <span>날짜 : {date.toISOString().split('T')[0]} 결제</span>
-            <span>주문번호 : No. {orderNumber}</span>
+            <span>날짜 : {date} 결제</span>
+            <span>주문번호 : {orderNumber}</span>
           </div>
 
           <h2
             className={`text-[20px] font-medium mt-1 text-pace-gray-500 ${textColorClass}`}
           >
-            {items[0]}
+            {firstTitle}
           </h2>
 
           <button
@@ -100,8 +94,10 @@ export default function PurchasesList({
 
           {isExpanded && (
             <ul className={`mt-2 font-light space-y-2 ${textColorClass}`}>
-              {items.map((item, idx) => (
-                <li key={idx}>{item}</li>
+              {items.map((item) => (
+                <li key={item.id}>
+                  {item.type} · {item.title}
+                </li>
               ))}
             </ul>
           )}
@@ -110,21 +106,22 @@ export default function PurchasesList({
             <span
               className={`text-pace-lg font-bold text-pace-gray-500 ${textColorClass}`}
             >
-              ${amount}
+              {formatMoneyFromCents(amountCents, currency)}
             </span>
             <span
               className={`ml-2 font-light text-pace-sm text-pace-gray-700 ${textColorClass}`}
             >
-              {status}
+              {statusLabel}
             </span>
           </div>
         </div>
 
         <PurchaseDetailsPopup
-          orderNumber={orderDetailData.orderNumber}
-          date={orderDetailData.date}
-          items={orderDetailData.items}
-          payment={orderDetailData.payment}
+          orderNumber={orderNumber}
+          date={date}
+          items={items}
+          payment={payment}
+          receiptUrl={receiptUrl}
         />
       </div>
     </div>

--- a/src/components/features/mypage/purchases/save-receipt-popup.tsx
+++ b/src/components/features/mypage/purchases/save-receipt-popup.tsx
@@ -13,12 +13,16 @@ import {
 type DetailPopupProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  receiptUrl?: string | null;
 };
 
 export default function SaveReceiptPopup({
   open,
-  onOpenChange
+  onOpenChange,
+  receiptUrl
 }: DetailPopupProps) {
+  const hasReceipt = Boolean(receiptUrl);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger className="flex-1 border border-orange-500 text-orange-500 rounded-full px-10 py-4 hover:bg-orange-50">
@@ -33,15 +37,30 @@ export default function SaveReceiptPopup({
             영수증 저장
           </DialogTitle>
           <DialogDescription className="text-center font-light !text-pace-base text-pace-gray-700">
-            영수증을 저장 하시겠습니까?
+            {hasReceipt
+              ? 'Stripe 영수증을 새 창에서 여시겠습니까?'
+              : '아직 연결된 영수증이 없습니다.'}
           </DialogDescription>
         </DialogHeader>
 
         <DialogFooter>
           <div className="flex gap-2">
-            <button className="px-10 py-4 rounded-full bg-pace-orange-800 text-white">
-              확인
-            </button>
+            {receiptUrl ? (
+              <a
+                href={receiptUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="px-10 py-4 rounded-full bg-pace-orange-800 text-white"
+              >
+                확인
+              </a>
+            ) : (
+              <DialogClose asChild>
+                <button className="px-10 py-4 rounded-full bg-pace-orange-800 text-white">
+                  확인
+                </button>
+              </DialogClose>
+            )}
             <DialogClose asChild>
               <button className="px-10 py-4 rounded-full border-2 border-pace-stone-800 text-pace-stone-800">
                 취소

--- a/src/components/features/mypage/purchases/save-receipt-popup.tsx
+++ b/src/components/features/mypage/purchases/save-receipt-popup.tsx
@@ -25,8 +25,11 @@ export default function SaveReceiptPopup({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogTrigger className="flex-1 border border-orange-500 text-orange-500 rounded-full px-10 py-4 hover:bg-orange-50">
-        영수증 저장
+      <DialogTrigger
+        disabled={!hasReceipt}
+        className="flex-1 border border-orange-500 text-orange-500 rounded-full px-10 py-4 hover:bg-orange-50 disabled:cursor-not-allowed disabled:border-pace-stone-300 disabled:text-pace-stone-500 disabled:hover:bg-transparent"
+      >
+        {hasReceipt ? '영수증 저장' : '영수증 준비중'}
       </DialogTrigger>
       <DialogContent
         showCloseButton={false}

--- a/src/lib/__tests__/order-display.test.ts
+++ b/src/lib/__tests__/order-display.test.ts
@@ -87,6 +87,26 @@ describe('order display helpers', () => {
     ]);
   });
 
+  it('passes optional order status filters to the order query', async () => {
+    prismaMock.order.findMany.mockResolvedValue([]);
+
+    await getOrderDisplaysForUser('33333333-3333-4333-8333-333333333333', [
+      OrderStatus.COMPLETED,
+      OrderStatus.REFUNDED
+    ]);
+
+    expect(prismaMock.order.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: '33333333-3333-4333-8333-333333333333',
+          status: {
+            in: [OrderStatus.COMPLETED, OrderStatus.REFUNDED]
+          }
+        }
+      })
+    );
+  });
+
   it('keeps fallback item data when catalog content is missing', async () => {
     prismaMock.order.findMany.mockResolvedValue([
       {

--- a/src/lib/__tests__/order-display.test.ts
+++ b/src/lib/__tests__/order-display.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+
+const prismaMock = {
+  order: {
+    findMany: vi.fn()
+  },
+  course: {
+    findUnique: vi.fn()
+  },
+  ebook: {
+    findUnique: vi.fn()
+  },
+  workshop: {
+    findUnique: vi.fn()
+  },
+  video: {
+    findUnique: vi.fn()
+  }
+};
+
+vi.mock('../prisma', () => ({
+  default: prismaMock
+}));
+
+const { getOrderDisplaysForUser } = await import('../order-display');
+
+describe('order display helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps real order rows to purchase display data', async () => {
+    const orderedAt = new Date('2026-06-07T12:00:00.000Z');
+
+    prismaMock.order.findMany.mockResolvedValue([
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        status: OrderStatus.COMPLETED,
+        orderedAt,
+        currency: 'cad',
+        subtotalAmountCents: 4999,
+        discountAmountCents: 0,
+        taxAmountCents: 0,
+        totalAmountCents: 4999,
+        stripeCheckoutSessionId: 'cs_test_123',
+        stripeReceiptUrl: 'https://stripe.test/receipt',
+        stripeInvoiceUrl: null,
+        items: [
+          {
+            id: 'item-1',
+            itemId: '11111111-1111-4111-8111-111111111111',
+            itemType: ItemType.COURSE,
+            priceAtPurchaseCents: 4999,
+            quantity: 1
+          }
+        ]
+      }
+    ]);
+    prismaMock.course.findUnique.mockResolvedValue({
+      id: '11111111-1111-4111-8111-111111111111',
+      title: 'Checkout Course',
+      category: 'INTERVIEW',
+      thumbnailUrl: 'https://cdn.test/course.jpg'
+    });
+
+    const orders = await getOrderDisplaysForUser(
+      '33333333-3333-4333-8333-333333333333'
+    );
+
+    expect(orders).toEqual([
+      expect.objectContaining({
+        id: '22222222-2222-4222-8222-222222222222',
+        orderNumber: 'No. 22222222',
+        statusLabel: '결제완료',
+        totalAmountCents: 4999,
+        stripeReceiptUrl: 'https://stripe.test/receipt',
+        items: [
+          expect.objectContaining({
+            title: 'Checkout Course',
+            typeLabel: '온라인 강의',
+            category: 'INTERVIEW',
+            actionHref: '/courses/11111111-1111-4111-8111-111111111111'
+          })
+        ]
+      })
+    ]);
+  });
+
+  it('keeps fallback item data when catalog content is missing', async () => {
+    prismaMock.order.findMany.mockResolvedValue([
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        status: OrderStatus.PENDING,
+        orderedAt: new Date('2026-06-07T12:00:00.000Z'),
+        currency: 'cad',
+        subtotalAmountCents: null,
+        discountAmountCents: null,
+        taxAmountCents: null,
+        totalAmountCents: 2500,
+        stripeCheckoutSessionId: null,
+        stripeReceiptUrl: null,
+        stripeInvoiceUrl: null,
+        items: [
+          {
+            id: 'item-1',
+            itemId: 'missing-course',
+            itemType: ItemType.COURSE,
+            priceAtPurchaseCents: 2500,
+            quantity: 1
+          }
+        ]
+      }
+    ]);
+    prismaMock.course.findUnique.mockResolvedValue(null);
+
+    const orders = await getOrderDisplaysForUser(
+      '33333333-3333-4333-8333-333333333333'
+    );
+
+    expect(orders[0]).toMatchObject({
+      statusLabel: '결제확인중',
+      subtotalAmountCents: 2500,
+      discountAmountCents: 0,
+      taxAmountCents: 0,
+      items: [
+        expect.objectContaining({
+          title: '구매 항목',
+          actionHref: '/mypage/purchases'
+        })
+      ]
+    });
+  });
+});

--- a/src/lib/checkout-items.ts
+++ b/src/lib/checkout-items.ts
@@ -1,0 +1,350 @@
+import { ItemType, OrderStatus, Prisma } from '@prisma/client';
+import { amountToCents } from './money';
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const CHECKOUT_CURRENCY = 'cad';
+
+export class CheckoutError extends Error {
+  status: number;
+
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = 'CheckoutError';
+    this.status = status;
+  }
+}
+
+export type CheckoutSelection = {
+  itemId: string;
+  itemType: ItemType;
+};
+
+export type CheckoutCartItem = {
+  cartId: string;
+  cartItemId: string;
+  itemId: string;
+  itemType: ItemType;
+  title: string;
+  description: string | null;
+  category: string | null;
+  thumbnail: string | null;
+  startsAt: Date | null;
+  unitAmountCents: number;
+  quantity: number;
+};
+
+type CartRow = {
+  id: string;
+  itemId: string;
+  itemType: ItemType;
+};
+
+type PrismaTx = Prisma.TransactionClient;
+
+function isUuid(value: string) {
+  return UUID_PATTERN.test(value);
+}
+
+function selectionKey(selection: CheckoutSelection) {
+  return `${selection.itemType}:${selection.itemId}`;
+}
+
+function isItemType(value: unknown): value is ItemType {
+  return (
+    typeof value === 'string' &&
+    Object.values(ItemType).includes(value as ItemType)
+  );
+}
+
+function normalizePriceToCents(
+  price: number | string | null | undefined,
+  itemLabel: string
+) {
+  const amount =
+    typeof price === 'number'
+      ? price
+      : Number(String(price ?? '').replace(/[^0-9.-]+/g, ''));
+
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new CheckoutError(`${itemLabel} has an invalid price`, 400);
+  }
+
+  return amountToCents(amount);
+}
+
+export function parseCheckoutSelections(body: unknown): CheckoutSelection[] {
+  const value = body as {
+    items?: unknown;
+    selectedItems?: unknown;
+  };
+  const rawItems = value.selectedItems ?? value.items;
+
+  if (!Array.isArray(rawItems) || rawItems.length === 0) {
+    throw new CheckoutError('No checkout items selected', 400);
+  }
+
+  const unique = new Map<string, CheckoutSelection>();
+
+  for (const rawItem of rawItems) {
+    const item = rawItem as { itemId?: unknown; itemType?: unknown };
+    const itemId = typeof item.itemId === 'string' ? item.itemId.trim() : '';
+
+    if (!itemId || !isItemType(item.itemType)) {
+      throw new CheckoutError('Invalid checkout item selection', 400);
+    }
+
+    const selection = { itemId, itemType: item.itemType };
+    unique.set(selectionKey(selection), selection);
+  }
+
+  return [...unique.values()];
+}
+
+async function resolveCartItem(
+  tx: PrismaTx,
+  cart: CartRow
+): Promise<CheckoutCartItem | null> {
+  switch (cart.itemType) {
+    case ItemType.COURSE: {
+      if (!isUuid(cart.itemId)) return null;
+
+      const course = await tx.course.findUnique({
+        where: { id: cart.itemId },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          category: true,
+          thumbnailUrl: true
+        }
+      });
+
+      if (!course) return null;
+
+      const title = course.title || 'Untitled course';
+
+      return {
+        cartId: cart.id,
+        cartItemId: cart.itemId,
+        itemId: course.id,
+        itemType: cart.itemType,
+        title,
+        description: course.description,
+        category: course.category,
+        thumbnail: course.thumbnailUrl,
+        startsAt: null,
+        unitAmountCents: normalizePriceToCents(course.price, title),
+        quantity: 1
+      };
+    }
+    case ItemType.EBOOK: {
+      const ebook = await tx.ebook.findFirst({
+        where: {
+          OR: [
+            { ebookId: cart.itemId },
+            ...(isUuid(cart.itemId) ? [{ id: cart.itemId }] : [])
+          ]
+        },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          category: true,
+          thumbnail: true
+        }
+      });
+
+      if (!ebook) return null;
+
+      const title = ebook.title || 'Untitled ebook';
+
+      return {
+        cartId: cart.id,
+        cartItemId: cart.itemId,
+        itemId: ebook.id,
+        itemType: cart.itemType,
+        title,
+        description: ebook.description,
+        category: ebook.category,
+        thumbnail: ebook.thumbnail,
+        startsAt: null,
+        unitAmountCents: normalizePriceToCents(ebook.price, title),
+        quantity: 1
+      };
+    }
+    case ItemType.WORKSHOP: {
+      if (!isUuid(cart.itemId)) return null;
+
+      const workshop = await tx.workshop.findUnique({
+        where: { id: cart.itemId },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          category: true,
+          thumbnail: true,
+          startDate: true
+        }
+      });
+
+      if (!workshop) return null;
+
+      return {
+        cartId: cart.id,
+        cartItemId: cart.itemId,
+        itemId: workshop.id,
+        itemType: cart.itemType,
+        title: workshop.title,
+        description: workshop.description,
+        category: workshop.category,
+        thumbnail: workshop.thumbnail,
+        startsAt: workshop.startDate,
+        unitAmountCents: normalizePriceToCents(workshop.price, workshop.title),
+        quantity: 1
+      };
+    }
+    case ItemType.VIDEO: {
+      const video = await tx.video.findFirst({
+        where: {
+          OR: [
+            { videoId: cart.itemId },
+            ...(isUuid(cart.itemId) ? [{ id: cart.itemId }] : [])
+          ]
+        },
+        select: {
+          id: true,
+          title: true,
+          description: true,
+          price: true,
+          category: true,
+          thumbnail: true
+        }
+      });
+
+      if (!video) return null;
+
+      const title = video.title || 'Untitled video';
+
+      return {
+        cartId: cart.id,
+        cartItemId: cart.itemId,
+        itemId: video.id,
+        itemType: cart.itemType,
+        title,
+        description: video.description,
+        category: video.category,
+        thumbnail: video.thumbnail,
+        startsAt: null,
+        unitAmountCents: normalizePriceToCents(video.price, title),
+        quantity: 1
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export async function getCheckoutCartItems(
+  tx: PrismaTx,
+  userId: string,
+  selections: CheckoutSelection[]
+) {
+  if (!selections.length) {
+    throw new CheckoutError('No checkout items selected', 400);
+  }
+
+  const carts = await tx.cart.findMany({
+    where: {
+      userId,
+      OR: selections.map((selection) => ({
+        itemId: selection.itemId,
+        itemType: selection.itemType
+      }))
+    },
+    select: {
+      id: true,
+      itemId: true,
+      itemType: true
+    }
+  });
+
+  const cartsByKey = new Map(carts.map((cart) => [selectionKey(cart), cart]));
+  const missingSelections = selections.filter(
+    (selection) => !cartsByKey.has(selectionKey(selection))
+  );
+
+  if (missingSelections.length) {
+    throw new CheckoutError('Selected cart items were not found', 400);
+  }
+
+  const orderedCarts = selections.map(
+    (selection) => cartsByKey.get(selectionKey(selection)) as CartRow
+  );
+  const checkoutItems = await Promise.all(
+    orderedCarts.map((cart) => resolveCartItem(tx, cart))
+  );
+
+  if (checkoutItems.some((item) => !item)) {
+    throw new CheckoutError('One or more selected items are unavailable', 400);
+  }
+
+  return checkoutItems as CheckoutCartItem[];
+}
+
+export async function assertNoCompletedPurchases(
+  tx: PrismaTx,
+  userId: string,
+  items: CheckoutCartItem[]
+) {
+  const purchasedItems = await tx.orderItem.findMany({
+    where: {
+      OR: items.map((item) => ({
+        itemId: item.itemId,
+        itemType: item.itemType
+      })),
+      order: {
+        userId,
+        status: OrderStatus.COMPLETED
+      }
+    },
+    select: {
+      itemId: true,
+      itemType: true
+    }
+  });
+
+  if (!purchasedItems.length) return;
+
+  const purchasedKeys = new Set(
+    purchasedItems.map((item) => selectionKey(item))
+  );
+  const purchasedTitles = items
+    .filter((item) => purchasedKeys.has(selectionKey(item)))
+    .map((item) => item.title);
+
+  throw new CheckoutError(
+    `Already purchased: ${purchasedTitles.join(', ')}`,
+    409
+  );
+}
+
+export function calculateCheckoutTotals(items: CheckoutCartItem[]) {
+  const subtotalAmountCents = items.reduce(
+    (total, item) => total + item.unitAmountCents * item.quantity,
+    0
+  );
+  const discountAmountCents = 0;
+  const taxAmountCents = 0;
+
+  return {
+    subtotalAmountCents,
+    discountAmountCents,
+    taxAmountCents,
+    totalAmountCents: subtotalAmountCents - discountAmountCents + taxAmountCents
+  };
+}

--- a/src/lib/order-display.ts
+++ b/src/lib/order-display.ts
@@ -250,10 +250,14 @@ export async function getOrderDisplayById(orderId: string, userId: string) {
   return order ? toOrderDisplay(prisma, order) : null;
 }
 
-export async function getOrderDisplaysForUser(userId: string) {
+export async function getOrderDisplaysForUser(
+  userId: string,
+  statuses?: OrderStatus[]
+) {
   const orders = await prisma.order.findMany({
     where: {
-      userId
+      userId,
+      ...(statuses?.length ? { status: { in: statuses } } : {})
     },
     include: {
       items: true

--- a/src/lib/order-display.ts
+++ b/src/lib/order-display.ts
@@ -1,0 +1,267 @@
+import { ItemType, OrderStatus, Prisma } from '@prisma/client';
+import prisma from './prisma';
+
+type PrismaTx = Prisma.TransactionClient;
+type OrderWithItems = Prisma.OrderGetPayload<{
+  include: { items: true };
+}>;
+
+export type OrderDisplayItem = {
+  id: string;
+  itemId: string;
+  itemType: ItemType;
+  typeLabel: string;
+  title: string;
+  category: string | null;
+  thumbnail: string | null;
+  startsAt: Date | null;
+  priceCents: number;
+  quantity: number;
+  actionHref: string;
+  actionLabel: string;
+};
+
+export type OrderDisplay = {
+  id: string;
+  orderNumber: string;
+  status: OrderStatus;
+  statusLabel: string;
+  orderedAt: Date;
+  currency: string;
+  subtotalAmountCents: number;
+  discountAmountCents: number;
+  taxAmountCents: number;
+  totalAmountCents: number;
+  stripeCheckoutSessionId: string | null;
+  stripeReceiptUrl: string | null;
+  stripeInvoiceUrl: string | null;
+  items: OrderDisplayItem[];
+};
+
+export const orderStatusLabels: Record<OrderStatus, string> = {
+  PENDING: '결제확인중',
+  COMPLETED: '결제완료',
+  FAILED: '결제실패',
+  CANCELLED: '결제취소',
+  REFUNDED: '환불완료'
+};
+
+export const orderItemTypeLabels: Record<ItemType, string> = {
+  VIDEO: '온라인 강의',
+  COURSE: '온라인 강의',
+  EBOOK: '전자책',
+  WORKSHOP: '워크샵'
+};
+
+function formatOrderNumber(id: string) {
+  return `No. ${id.slice(0, 8).toUpperCase()}`;
+}
+
+function fallbackOrderItem(item: {
+  id: string;
+  itemId: string;
+  itemType: ItemType;
+  priceAtPurchaseCents: number;
+  quantity: number;
+}): OrderDisplayItem {
+  return {
+    id: item.id,
+    itemId: item.itemId,
+    itemType: item.itemType,
+    typeLabel: orderItemTypeLabels[item.itemType],
+    title: '구매 항목',
+    category: null,
+    thumbnail: null,
+    startsAt: null,
+    priceCents: item.priceAtPurchaseCents,
+    quantity: item.quantity,
+    actionHref: '/mypage/purchases',
+    actionLabel: 'View detail'
+  };
+}
+
+async function resolveOrderDisplayItem(
+  tx: PrismaTx,
+  item: OrderWithItems['items'][number]
+): Promise<OrderDisplayItem> {
+  const fallback = fallbackOrderItem(item);
+
+  switch (item.itemType) {
+    case ItemType.COURSE: {
+      const course = await tx.course.findUnique({
+        where: { id: item.itemId },
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          thumbnailUrl: true
+        }
+      });
+
+      if (!course) return fallback;
+
+      return {
+        ...fallback,
+        itemId: course.id,
+        title: course.title || fallback.title,
+        category: course.category,
+        thumbnail: course.thumbnailUrl,
+        actionHref: `/courses/${course.id}`,
+        actionLabel: '수강하러 가기'
+      };
+    }
+    case ItemType.EBOOK: {
+      const ebook = await tx.ebook.findUnique({
+        where: { id: item.itemId },
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          thumbnail: true
+        }
+      });
+
+      if (!ebook) return fallback;
+
+      return {
+        ...fallback,
+        itemId: ebook.id,
+        title: ebook.title || fallback.title,
+        category: ebook.category,
+        thumbnail: ebook.thumbnail,
+        actionHref: `/ebooks/${ebook.id}`,
+        actionLabel: '전자책 보기'
+      };
+    }
+    case ItemType.WORKSHOP: {
+      const workshop = await tx.workshop.findUnique({
+        where: { id: item.itemId },
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          thumbnail: true,
+          startDate: true
+        }
+      });
+
+      if (!workshop) return fallback;
+
+      return {
+        ...fallback,
+        itemId: workshop.id,
+        title: workshop.title,
+        category: workshop.category,
+        thumbnail: workshop.thumbnail,
+        startsAt: workshop.startDate,
+        actionHref: `/workshops/${workshop.id}`,
+        actionLabel: 'View detail'
+      };
+    }
+    case ItemType.VIDEO: {
+      const video = await tx.video.findUnique({
+        where: { id: item.itemId },
+        select: {
+          id: true,
+          title: true,
+          category: true,
+          thumbnail: true
+        }
+      });
+
+      if (!video) return fallback;
+
+      return {
+        ...fallback,
+        itemId: video.id,
+        title: video.title || fallback.title,
+        category: video.category,
+        thumbnail: video.thumbnail,
+        actionHref: '/courses',
+        actionLabel: '수강하러 가기'
+      };
+    }
+    default:
+      return fallback;
+  }
+}
+
+async function toOrderDisplay(
+  tx: PrismaTx,
+  order: OrderWithItems
+): Promise<OrderDisplay> {
+  const items = await Promise.all(
+    order.items.map((item) => resolveOrderDisplayItem(tx, item))
+  );
+  const itemSubtotal = items.reduce(
+    (total, item) => total + item.priceCents * item.quantity,
+    0
+  );
+  const subtotalAmountCents = order.subtotalAmountCents ?? itemSubtotal;
+  const discountAmountCents = order.discountAmountCents ?? 0;
+  const taxAmountCents = order.taxAmountCents ?? 0;
+
+  return {
+    id: order.id,
+    orderNumber: formatOrderNumber(order.id),
+    status: order.status,
+    statusLabel: orderStatusLabels[order.status],
+    orderedAt: order.orderedAt,
+    currency: order.currency,
+    subtotalAmountCents,
+    discountAmountCents,
+    taxAmountCents,
+    totalAmountCents: order.totalAmountCents,
+    stripeCheckoutSessionId: order.stripeCheckoutSessionId,
+    stripeReceiptUrl: order.stripeReceiptUrl,
+    stripeInvoiceUrl: order.stripeInvoiceUrl,
+    items
+  };
+}
+
+export async function getOrderDisplayBySessionId(
+  sessionId: string,
+  userId: string
+) {
+  const order = await prisma.order.findFirst({
+    where: {
+      userId,
+      stripeCheckoutSessionId: sessionId
+    },
+    include: {
+      items: true
+    }
+  });
+
+  return order ? toOrderDisplay(prisma, order) : null;
+}
+
+export async function getOrderDisplayById(orderId: string, userId: string) {
+  const order = await prisma.order.findFirst({
+    where: {
+      id: orderId,
+      userId
+    },
+    include: {
+      items: true
+    }
+  });
+
+  return order ? toOrderDisplay(prisma, order) : null;
+}
+
+export async function getOrderDisplaysForUser(userId: string) {
+  const orders = await prisma.order.findMany({
+    where: {
+      userId
+    },
+    include: {
+      items: true
+    },
+    orderBy: {
+      orderedAt: 'desc'
+    }
+  });
+
+  return Promise.all(orders.map((order) => toOrderDisplay(prisma, order)));
+}

--- a/src/lib/stripe-promotion-codes.ts
+++ b/src/lib/stripe-promotion-codes.ts
@@ -1,0 +1,139 @@
+import type Stripe from 'stripe';
+import { CheckoutError } from './checkout-items';
+
+const PROMOTION_CODE_PATTERN = /^[a-z0-9-]+$/i;
+const MAX_PROMOTION_CODE_LENGTH = 80;
+
+export type ValidatedPromotionCode = {
+  id: string;
+  code: string;
+};
+
+export function parseOptionalPromotionCode(body: unknown) {
+  const value = body as { promotionCode?: unknown };
+  const rawCode = value.promotionCode;
+
+  if (rawCode === undefined || rawCode === null) return null;
+  if (typeof rawCode !== 'string') {
+    throw new CheckoutError('Invalid promotion code', 400);
+  }
+
+  const code = rawCode.trim();
+  if (!code) return null;
+
+  if (
+    code.length > MAX_PROMOTION_CODE_LENGTH ||
+    !PROMOTION_CODE_PATTERN.test(code)
+  ) {
+    throw new CheckoutError('Invalid promotion code', 400);
+  }
+
+  return code;
+}
+
+function getMinimumAmountCents(
+  promotionCode: Stripe.PromotionCode,
+  currency: string
+) {
+  const currencyKey = currency.toLowerCase();
+  const currencyMinimum =
+    promotionCode.restrictions.currency_options?.[currencyKey]?.minimum_amount;
+
+  if (currencyMinimum !== undefined) return currencyMinimum;
+
+  if (
+    promotionCode.restrictions.minimum_amount !== null &&
+    promotionCode.restrictions.minimum_amount_currency?.toLowerCase() ===
+      currencyKey
+  ) {
+    return promotionCode.restrictions.minimum_amount;
+  }
+
+  return null;
+}
+
+function hasMinimumAmountForAnotherCurrency(
+  promotionCode: Stripe.PromotionCode,
+  currency: string
+) {
+  const currencyKey = currency.toLowerCase();
+  const hasCurrentCurrencyOption =
+    promotionCode.restrictions.currency_options?.[currencyKey] !== undefined;
+
+  return (
+    !hasCurrentCurrencyOption &&
+    promotionCode.restrictions.minimum_amount !== null &&
+    promotionCode.restrictions.minimum_amount_currency !== null &&
+    promotionCode.restrictions.minimum_amount_currency.toLowerCase() !==
+      currencyKey
+  );
+}
+
+function isPublicPromotionCode(promotionCode: Stripe.PromotionCode) {
+  return !promotionCode.customer && !promotionCode.customer_account;
+}
+
+export async function validateStripePromotionCode(
+  stripe: Stripe,
+  {
+    code,
+    subtotalAmountCents,
+    currency,
+    hasCompletedOrder
+  }: {
+    code: string;
+    subtotalAmountCents: number;
+    currency: string;
+    hasCompletedOrder: boolean;
+  }
+): Promise<ValidatedPromotionCode> {
+  const promotionCodes = await stripe.promotionCodes.list({
+    code,
+    active: true,
+    limit: 10
+  });
+  const promotionCode = promotionCodes.data.find(isPublicPromotionCode);
+
+  if (!promotionCode) {
+    throw new CheckoutError('Invalid promotion code', 400);
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (promotionCode.expires_at && promotionCode.expires_at <= now) {
+    throw new CheckoutError('Promotion code has expired', 400);
+  }
+
+  if (
+    promotionCode.max_redemptions !== null &&
+    promotionCode.times_redeemed >= promotionCode.max_redemptions
+  ) {
+    throw new CheckoutError('Promotion code has already been redeemed', 400);
+  }
+
+  if (promotionCode.restrictions.first_time_transaction && hasCompletedOrder) {
+    throw new CheckoutError(
+      'Promotion code is only available for first-time customers',
+      400
+    );
+  }
+
+  if (hasMinimumAmountForAnotherCurrency(promotionCode, currency)) {
+    throw new CheckoutError(
+      'Promotion code is not valid for this currency',
+      400
+    );
+  }
+
+  const minimumAmountCents = getMinimumAmountCents(promotionCode, currency);
+  if (minimumAmountCents !== null && subtotalAmountCents < minimumAmountCents) {
+    throw new CheckoutError(
+      'Promotion code requires a higher order subtotal',
+      400
+    );
+  }
+
+  return {
+    id: promotionCode.id,
+    code: promotionCode.code
+  };
+}


### PR DESCRIPTION
## Summary
- add Stripe Checkout session creation for selected cart items with server-side cart validation and order persistence
- wire cart checkout UI to Stripe, including promotion code validation and Stripe Checkout handoff
- replace post-payment and purchase history mock data with real order display data
- clarify promotion-code totals before webhook-finalized amounts are available
- update Stripe implementation plan with PACE-260 / PACE-261 scope split

## Testing
- npx vitest run src/components/features/mypage/cart/payment-summary.test.tsx
- npx tsc --noEmit --module esnext --incremental false --pretty false
- npm test -- --run
- npm run build

## Notes
- PACE-261 should complete webhook fulfillment, entitlement grants, cart cleanup, receipt amount reconciliation, and duplicate webhook/session idempotency.
- Build currently still reports the pre-existing unused variable warning in src/components/admin/ebooks/actions/ebook-actions.ts.
- The env variables should be added your `.env.local` : https://pacemakerworld.slack.com/archives/C089UQBR4JF/p1780946747485329