### PR TITLE
[PACE-261] Stripe webhook fulfillment and entitlements

### DIFF
--- a/src/app/admin/courses/page.tsx
+++ b/src/app/admin/courses/page.tsx
@@ -11,7 +11,6 @@ import PaceSelect from '@/components/ui/admin/select';
 import { itemCategoryLabel } from '@/constants/labels';
 import { toast } from 'sonner';
 import ConfirmModal from '@/components/common/confirm-modal';
-import { resolveImageSrc } from '@/lib/utils';
 import {
   DndContext,
   closestCenter,

--- a/src/app/admin/workshops/page.tsx
+++ b/src/app/admin/workshops/page.tsx
@@ -12,7 +12,6 @@ import AdminVisualRow, {
 import { generateKeyBetween } from 'fractional-indexing';
 import { toast } from 'sonner';
 import ConfirmModal from '@/components/common/confirm-modal';
-import { resolveImageSrc } from '@/lib/utils';
 
 import {
   DndContext,
@@ -143,7 +142,6 @@ export default function Page() {
   // Status UI used by AdminVisualRow
   const WorkshopStatus = ({
     row,
-    toggleRow: _toggle,
     onStatusChange: _onStatusChange
   }: {
     row: RowLike;

--- a/src/app/api/courses/detail/[id]/route.test.ts
+++ b/src/app/api/courses/detail/[id]/route.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const prismaMock = {
+  course: {
+    findUnique: vi.fn(),
+    findMany: vi.fn()
+  },
+  user: {
+    findUnique: vi.fn()
+  },
+  orderItem: {
+    findFirst: vi.fn(),
+    findMany: vi.fn()
+  }
+};
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { GET } = await import('./route');
+
+function courseFixture() {
+  return {
+    id: 'course-123',
+    title: 'Paid Course',
+    description: 'Course description',
+    processTitle: null,
+    processContent: null,
+    videoLink: null,
+    price: '49.99',
+    time: null,
+    thumbnailUrl: null,
+    visualTitle: null,
+    visualTitle2: 'Paid Course Hero',
+    category: 'INTERVIEW',
+    targetAudienceTypes: [],
+    recommendedLinks: null,
+    instructors: [],
+    videos: [
+      {
+        id: 'video-db-1',
+        videoId: 'wistia123',
+        title: 'Private Wistia Video',
+        description: null,
+        price: null,
+        thumbnail: null,
+        category: null
+      },
+      {
+        id: 'video-db-2',
+        videoId: 'wistia456',
+        title: 'Purchased Single Video',
+        description: null,
+        price: 25,
+        thumbnail: null,
+        category: null
+      }
+    ],
+    sectionsRel: [
+      {
+        id: 'section-1',
+        title: 'Section 1',
+        description: null,
+        orderIndex: 0,
+        videos: [
+          {
+            id: 'video-db-1',
+            videoId: 'wistia123',
+            title: 'Private Wistia Video',
+            description: null,
+            price: null,
+            thumbnail: null,
+            category: null
+          },
+          {
+            id: 'video-db-2',
+            videoId: 'wistia456',
+            title: 'Purchased Single Video',
+            description: null,
+            price: 25,
+            thumbnail: null,
+            category: null
+          }
+        ]
+      }
+    ],
+    reviews: []
+  };
+}
+
+function context() {
+  return {
+    params: Promise.resolve({ id: 'course-123' })
+  };
+}
+
+describe('GET /api/courses/detail/[id]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.course.findUnique.mockResolvedValue(courseFixture());
+    prismaMock.course.findMany.mockResolvedValue([]);
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-123' });
+    prismaMock.orderItem.findFirst.mockResolvedValue(null);
+    prismaMock.orderItem.findMany.mockResolvedValue([]);
+  });
+
+  it('strips playable video ids for users without completed purchases', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+
+    const response = await GET(new Request('http://localhost'), context());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.entitlements).toEqual({
+      requiresPurchase: true,
+      canAccessCourse: false
+    });
+    expect(data.data.course.videos[0].videoId).toBe('');
+    expect(data.data.course.videos[0].canAccessVideo).toBe(false);
+    expect(data.data.course.sections[0].videos[0].videoId).toBe('');
+    expect(data.data.course.sections[0].videos[0].canAccessVideo).toBe(false);
+  });
+
+  it('keeps all playable video ids for completed course purchasers', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk_user_123' } as never);
+    prismaMock.orderItem.findFirst.mockResolvedValue({
+      id: 'order-item-123'
+    });
+
+    const response = await GET(new Request('http://localhost'), context());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.entitlements).toEqual({
+      requiresPurchase: true,
+      canAccessCourse: true
+    });
+    expect(data.data.course.videos[0].videoId).toBe('wistia123');
+    expect(data.data.course.videos[0].canAccessVideo).toBe(true);
+    expect(data.data.course.videos[1].videoId).toBe('wistia456');
+    expect(data.data.course.videos[1].canAccessVideo).toBe(true);
+    expect(data.data.course.sections[0].videos[0].videoId).toBe('wistia123');
+  });
+
+  it('keeps only individually purchased video ids when the course is not purchased', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk_user_123' } as never);
+    prismaMock.orderItem.findFirst.mockResolvedValue(null);
+    prismaMock.orderItem.findMany.mockResolvedValue([
+      {
+        itemId: 'video-db-2'
+      }
+    ]);
+
+    const response = await GET(new Request('http://localhost'), context());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.entitlements).toEqual({
+      requiresPurchase: true,
+      canAccessCourse: false
+    });
+    expect(data.data.course.videos[0].videoId).toBe('');
+    expect(data.data.course.videos[0].canAccessVideo).toBe(false);
+    expect(data.data.course.videos[1].videoId).toBe('wistia456');
+    expect(data.data.course.videos[1].canAccessVideo).toBe(true);
+    expect(data.data.course.sections[0].videos[0].videoId).toBe('');
+    expect(data.data.course.sections[0].videos[1].videoId).toBe('wistia456');
+  });
+});

--- a/src/app/api/courses/detail/[id]/route.ts
+++ b/src/app/api/courses/detail/[id]/route.ts
@@ -1,7 +1,14 @@
 import prisma from '@/lib/prisma';
 import { NextResponse } from 'next/server';
 import { TARGET_AUDIENCE_MAPPING } from '@/constants/target-audience';
+import { auth } from '@clerk/nextjs/server';
 import { TargetAudienceType } from '@prisma/client';
+import {
+  findUserIdByClerkId,
+  getAccessibleCourseVideoIds,
+  isFreePrice,
+  userCanAccessCourse
+} from '@/lib/entitlements';
 
 const TARGET_AUDIENCE_REVERSE_MAP: Record<TargetAudienceType, string> = {
   [TargetAudienceType.IT]: 'IT 개발',
@@ -48,12 +55,26 @@ interface ResolvedCourse {
   linkUrl: string;
 }
 
+function applyVideoEntitlement<T extends { id: string; videoId: string }>(
+  video: T,
+  accessibleVideoIds: Set<string>
+) {
+  const canAccessVideo = accessibleVideoIds.has(video.id);
+
+  return {
+    ...video,
+    canAccessVideo,
+    videoId: canAccessVideo ? video.videoId : ''
+  };
+}
+
 export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
     const { id } = await params;
+    const { userId: clerkUserId } = await auth();
 
     const courseData = await prisma.course.findUnique({
       where: { id },
@@ -94,6 +115,26 @@ export async function GET(
         { status: 404 }
       );
     }
+
+    const videoIds = [
+      ...new Set([
+        ...courseData.videos.map((video) => video.id),
+        ...courseData.sectionsRel.flatMap((section) =>
+          section.videos.map((video) => video.id)
+        )
+      ])
+    ];
+    const userId = clerkUserId
+      ? await findUserIdByClerkId(prisma, clerkUserId)
+      : null;
+    const courseEntitlement = {
+      id: courseData.id,
+      price: courseData.price
+    };
+    const [canAccessCourse, accessibleVideoIds] = await Promise.all([
+      userCanAccessCourse(prisma, userId, courseEntitlement),
+      getAccessibleCourseVideoIds(prisma, userId, courseEntitlement, videoIds)
+    ]);
 
     // 관련 강의 가져오기 (같은 카테고리 우선, 현재 강의 제외)
     let relatedCoursesData = await prisma.course.findMany({
@@ -174,9 +215,14 @@ export async function GET(
     // DB 구조를 Frontend 구조로 변환
     const course = {
       ...courseData,
+      videos: courseData.videos.map((video) =>
+        applyVideoEntitlement(video, accessibleVideoIds)
+      ),
       sections: (courseData.sectionsRel || []).map((section) => ({
         ...section,
-        videos: section.videos || []
+        videos: (section.videos || []).map((video) =>
+          applyVideoEntitlement(video, accessibleVideoIds)
+        )
       })),
       targetAudiences: (courseData.targetAudienceTypes || []).map((type) => {
         const mapping = TARGET_AUDIENCE_MAPPING[type as TargetAudienceType];
@@ -210,7 +256,11 @@ export async function GET(
         success: true,
         data: {
           course,
-          instructors: course.instructors
+          instructors: course.instructors,
+          entitlements: {
+            requiresPurchase: !isFreePrice(courseData.price),
+            canAccessCourse
+          }
         }
       },
       { status: 200 }

--- a/src/app/api/ebooks/handler.test.ts
+++ b/src/app/api/ebooks/handler.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const prismaMock = {
+  ebook: {
+    findUnique: vi.fn()
+  },
+  user: {
+    findUnique: vi.fn()
+  },
+  orderItem: {
+    findFirst: vi.fn()
+  }
+};
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  bucketName: 'ebooks',
+  s3clientSupabase: {}
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { createGetHandler } = await import('./handler');
+
+function context(ebookId = 'ebook-123') {
+  return {
+    params: Promise.resolve({ ebookId })
+  };
+}
+
+describe('ebook file handler', () => {
+  const s3Client = {
+    send: vi.fn()
+  };
+  const GET = createGetHandler(s3Client as never);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk_user_123' } as never);
+    prismaMock.ebook.findUnique.mockResolvedValue({
+      id: 'ebook-123',
+      ebookId: 'ebook-file.pdf',
+      price: 25
+    });
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-123' });
+    prismaMock.orderItem.findFirst.mockResolvedValue({
+      id: 'order-item-123'
+    });
+    s3Client.send.mockResolvedValue({
+      Body: {
+        [Symbol.asyncIterator]: async function* () {
+          yield Buffer.from('pdf');
+        },
+        destroy: vi.fn()
+      }
+    });
+  });
+
+  it('requires authentication', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    expect(s3Client.send).not.toHaveBeenCalled();
+  });
+
+  it('blocks paid ebooks without a completed purchase', async () => {
+    prismaMock.orderItem.findFirst.mockResolvedValue(null);
+
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'Purchase required to view this ebook'
+    });
+    expect(s3Client.send).not.toHaveBeenCalled();
+  });
+
+  it('streams purchased ebook PDFs', async () => {
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/pdf');
+    expect(s3Client.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          Bucket: 'ebooks',
+          Key: 'ebook-file.pdf'
+        })
+      })
+    );
+  });
+});

--- a/src/app/api/ebooks/handler.ts
+++ b/src/app/api/ebooks/handler.ts
@@ -4,6 +4,7 @@ import { GetObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Readable } from 'stream';
 import { bucketName } from '@/lib/supabase';
 import prisma from '@/lib/prisma';
+import { findUserIdByClerkId, userCanAccessEbook } from '@/lib/entitlements';
 
 function nodeReadableToWebReadable(
   nodeStream: Readable
@@ -48,13 +49,29 @@ export function createGetHandler(s3Client: S3Client) {
           id: ebookId
         },
         select: {
+          id: true,
+          price: true,
           ebookId: true
         }
       });
 
+      if (!ebook) {
+        return NextResponse.json({ error: 'Ebook not found' }, { status: 404 });
+      }
+
+      const userId = await findUserIdByClerkId(prisma, session.userId);
+      const canAccessEbook = await userCanAccessEbook(prisma, userId, ebook);
+
+      if (!canAccessEbook) {
+        return NextResponse.json(
+          { error: 'Purchase required to view this ebook' },
+          { status: 403 }
+        );
+      }
+
       const command = new GetObjectCommand({
         Bucket: bucketName,
-        Key: ebook?.ebookId
+        Key: ebook.ebookId
       });
 
       const response = await s3Client.send(command);

--- a/src/app/api/ebooks/route.test.ts
+++ b/src/app/api/ebooks/route.test.ts
@@ -8,13 +8,21 @@ vi.mock('@clerk/nextjs/server', () => ({
   auth: vi.fn()
 }));
 
+const prismaMock = vi.hoisted(() => ({
+  ebook: {
+    findUnique: vi.fn()
+  },
+  user: {
+    findUnique: vi.fn()
+  },
+  orderItem: {
+    findFirst: vi.fn()
+  }
+}));
+
 vi.mock('@/lib/prisma', () => {
   return {
-    default: {
-      ebook: {
-        findUnique: vi.fn()
-      }
-    }
+    default: prismaMock
   };
 });
 
@@ -36,6 +44,17 @@ describe('GET /api/ebooks/[ebookId]', () => {
 
     (auth as unknown as Mock).mockResolvedValue({
       userId: 'user_123'
+    });
+    prismaMock.ebook.findUnique.mockResolvedValue({
+      id: ebookId,
+      ebookId: 'ebook-file.pdf',
+      price: 25
+    });
+    prismaMock.user.findUnique.mockResolvedValue({
+      id: 'app-user-123'
+    });
+    prismaMock.orderItem.findFirst.mockResolvedValue({
+      id: 'order-item-123'
     });
 
     GET = createGetHandler(mockS3ClientInstance as unknown as S3Client);

--- a/src/app/api/purchase-video-status/route.ts
+++ b/src/app/api/purchase-video-status/route.ts
@@ -1,23 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { auth } from '@clerk/nextjs/server';
 import { ItemType } from '@prisma/client';
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const clerkId = searchParams.get('clerkId');
+    const { userId: authenticatedClerkId } = await auth();
 
-    if (!clerkId) {
-      return NextResponse.json(
-        { error: 'User ID is required' },
-        { status: 400 }
-      );
+    if (!authenticatedClerkId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (clerkId && clerkId !== authenticatedClerkId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     // Find user by clerk ID
     const currentUser = await prisma.user.findFirst({
       where: {
-        clerkId: clerkId
+        clerkId: authenticatedClerkId
       },
       select: {
         id: true

--- a/src/app/api/stripe/checkout-webhook-flow.test.ts
+++ b/src/app/api/stripe/checkout-webhook-flow.test.ts
@@ -1,0 +1,557 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+import type Stripe from 'stripe';
+import type { Mock } from 'vitest';
+
+type CartRow = {
+  id: string;
+  userId: string;
+  itemId: string;
+  itemType: ItemType;
+};
+
+type CatalogVideo = {
+  id: string;
+  videoId: string;
+  title: string;
+  description: string | null;
+  price: string;
+  category: string | null;
+  thumbnail: string | null;
+};
+
+type CatalogEbook = {
+  id: string;
+  ebookId: string;
+  title: string;
+  description: string | null;
+  price: string;
+  category: string | null;
+  thumbnail: string | null;
+};
+
+type OrderItemRow = {
+  id: string;
+  orderId: string;
+  itemId: string;
+  itemType: ItemType;
+  priceAtPurchaseCents: number;
+  quantity: number;
+};
+
+type OrderRow = {
+  id: string;
+  userId: string | null;
+  totalAmountCents: number;
+  subtotalAmountCents: number | null;
+  discountAmountCents: number | null;
+  taxAmountCents: number | null;
+  currency: string;
+  status: OrderStatus;
+  stripeCheckoutSessionId: string | null;
+  stripePaymentIntentId: string | null;
+  stripeCustomerId: string | null;
+  stripeInvoiceId: string | null;
+  stripeInvoiceUrl: string | null;
+  stripeReceiptUrl: string | null;
+  items: OrderItemRow[];
+};
+
+const userId = '33333333-3333-4333-8333-333333333333';
+const clerkUserId = 'clerk_user_flow';
+const orderId = '22222222-2222-4222-8222-222222222222';
+const checkoutSessionId = 'cs_flow_123';
+const videoExternalId = 'wistia_flow_001';
+const videoDbId = '44444444-4444-4444-8444-444444444444';
+const ebookExternalId = 'flow-ebook.pdf';
+const ebookDbId = '55555555-5555-4555-8555-555555555555';
+
+const db: {
+  carts: CartRow[];
+  videos: CatalogVideo[];
+  ebooks: CatalogEbook[];
+  orders: OrderRow[];
+} = {
+  carts: [],
+  videos: [],
+  ebooks: [],
+  orders: []
+};
+
+const tx = {
+  cart: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn()
+  },
+  course: {
+    findUnique: vi.fn()
+  },
+  ebook: {
+    findFirst: vi.fn(),
+    findMany: vi.fn()
+  },
+  workshop: {
+    findUnique: vi.fn()
+  },
+  video: {
+    findFirst: vi.fn(),
+    findMany: vi.fn()
+  },
+  orderItem: {
+    findMany: vi.fn()
+  },
+  order: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn()
+  },
+  userWorkshop: {
+    upsert: vi.fn()
+  }
+};
+
+const prismaMock = {
+  user: {
+    findUnique: vi.fn()
+  },
+  order: {
+    update: vi.fn()
+  },
+  $transaction: vi.fn()
+};
+
+const stripeSessionCreateMock = vi.fn();
+const stripeConstructEventMock = vi.fn();
+const stripePaymentIntentRetrieveMock = vi.fn();
+const stripeInvoiceRetrieveMock = vi.fn();
+const stripePromotionCodesListMock = vi.fn();
+const stripeClientMock = {
+  checkout: {
+    sessions: {
+      create: stripeSessionCreateMock
+    }
+  },
+  webhooks: {
+    constructEvent: stripeConstructEventMock
+  },
+  paymentIntents: {
+    retrieve: stripePaymentIntentRetrieveMock
+  },
+  invoices: {
+    retrieve: stripeInvoiceRetrieveMock
+  },
+  promotionCodes: {
+    list: stripePromotionCodesListMock
+  }
+};
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: vi.fn(() => stripeClientMock)
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { POST: createCheckoutSession } =
+  await import('./create-checkout-session/route');
+const { POST: receiveStripeWebhook } = await import('./webhook/route');
+
+function createCheckoutRequest() {
+  return new Request(
+    'http://localhost:3000/api/stripe/create-checkout-session',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        origin: 'http://localhost:3000'
+      },
+      body: JSON.stringify({
+        selectedItems: [
+          { itemId: videoExternalId, itemType: ItemType.VIDEO },
+          { itemId: ebookExternalId, itemType: ItemType.EBOOK }
+        ]
+      })
+    }
+  );
+}
+
+function createWebhookRequest() {
+  return new Request('http://localhost:3000/api/stripe/webhook', {
+    method: 'POST',
+    headers: {
+      'stripe-signature': 'valid-signature'
+    },
+    body: JSON.stringify({ id: 'evt_flow_123' })
+  });
+}
+
+function checkoutSessionEvent(
+  paymentStatus: Stripe.Checkout.Session['payment_status']
+): Stripe.Event {
+  return {
+    id: 'evt_flow_123',
+    type: 'checkout.session.completed',
+    data: {
+      object: {
+        id: checkoutSessionId,
+        client_reference_id: orderId,
+        metadata: {
+          orderId
+        },
+        payment_status: paymentStatus,
+        amount_subtotal: 3050,
+        amount_total: 3050,
+        total_details: {
+          amount_discount: 0,
+          amount_shipping: 0,
+          amount_tax: 0
+        },
+        currency: 'cad',
+        payment_intent: 'pi_flow_123',
+        customer: 'cus_flow_123',
+        invoice: 'in_flow_123'
+      } as unknown as Stripe.Checkout.Session
+    }
+  } as Stripe.Event;
+}
+
+function orderMatchesFilter(
+  order: OrderRow,
+  condition: Record<string, string>
+) {
+  if ('id' in condition) return order.id === condition.id;
+  if ('stripeCheckoutSessionId' in condition) {
+    return order.stripeCheckoutSessionId === condition.stripeCheckoutSessionId;
+  }
+  return false;
+}
+
+function updateOrder(args: { where: { id: string }; data: Partial<OrderRow> }) {
+  const order = db.orders.find((row) => row.id === args.where.id);
+
+  if (!order) throw new Error(`Order not found: ${args.where.id}`);
+
+  Object.assign(order, args.data);
+  return Promise.resolve(order);
+}
+
+function resetFlowState() {
+  db.carts = [
+    {
+      id: 'cart-video',
+      userId,
+      itemId: videoExternalId,
+      itemType: ItemType.VIDEO
+    },
+    {
+      id: 'cart-ebook',
+      userId,
+      itemId: ebookExternalId,
+      itemType: ItemType.EBOOK
+    }
+  ];
+  db.videos = [
+    {
+      id: videoDbId,
+      videoId: videoExternalId,
+      title: 'Flow Video',
+      description: 'Video in checkout flow',
+      price: '20.00',
+      category: 'INTERVIEW',
+      thumbnail: null
+    }
+  ];
+  db.ebooks = [
+    {
+      id: ebookDbId,
+      ebookId: ebookExternalId,
+      title: 'Flow Ebook',
+      description: 'Ebook in checkout flow',
+      price: '10.50',
+      category: 'RESUME',
+      thumbnail: null
+    }
+  ];
+  db.orders = [];
+}
+
+function installPrismaBehavior() {
+  prismaMock.user.findUnique.mockResolvedValue({
+    id: userId,
+    email: 'buyer@example.com'
+  });
+  prismaMock.$transaction.mockImplementation(async (callback) => callback(tx));
+  prismaMock.order.update.mockImplementation(updateOrder);
+
+  tx.cart.findMany.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.carts.filter(
+        (cart) =>
+          cart.userId === where.userId &&
+          where.OR.some(
+            (selection: { itemId: string; itemType: ItemType }) =>
+              cart.itemId === selection.itemId &&
+              cart.itemType === selection.itemType
+          )
+      )
+    )
+  );
+  tx.cart.deleteMany.mockImplementation(({ where }) => {
+    const originalCount = db.carts.length;
+    db.carts = db.carts.filter(
+      (cart) =>
+        cart.userId !== where.userId ||
+        !where.OR.some(
+          (filter: { itemId: string; itemType: ItemType }) =>
+            cart.itemId === filter.itemId && cart.itemType === filter.itemType
+        )
+    );
+
+    return Promise.resolve({ count: originalCount - db.carts.length });
+  });
+  tx.video.findFirst.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.videos.find((video) =>
+        where.OR.some(
+          (condition: { id?: string; videoId?: string }) =>
+            video.id === condition.id || video.videoId === condition.videoId
+        )
+      ) ?? null
+    )
+  );
+  tx.video.findMany.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.videos
+        .filter((video) => where.id.in.includes(video.id))
+        .map(({ id, videoId }) => ({ id, videoId }))
+    )
+  );
+  tx.ebook.findFirst.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.ebooks.find((ebook) =>
+        where.OR.some(
+          (condition: { id?: string; ebookId?: string }) =>
+            ebook.id === condition.id || ebook.ebookId === condition.ebookId
+        )
+      ) ?? null
+    )
+  );
+  tx.ebook.findMany.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.ebooks
+        .filter((ebook) => where.id.in.includes(ebook.id))
+        .map(({ id, ebookId }) => ({ id, ebookId }))
+    )
+  );
+  tx.course.findUnique.mockResolvedValue(null);
+  tx.workshop.findUnique.mockResolvedValue(null);
+  tx.orderItem.findMany.mockImplementation(({ where }) =>
+    Promise.resolve(
+      db.orders
+        .filter(
+          (order) =>
+            order.userId === where.order.userId &&
+            order.status === where.order.status
+        )
+        .flatMap((order) => order.items)
+        .filter((item) =>
+          where.OR.some(
+            (selection: { itemId: string; itemType: ItemType }) =>
+              item.itemId === selection.itemId &&
+              item.itemType === selection.itemType
+          )
+        )
+        .map(({ itemId, itemType }) => ({ itemId, itemType }))
+    )
+  );
+  tx.order.findFirst.mockImplementation(({ where, include, select }) => {
+    let order: OrderRow | undefined;
+
+    if (where.OR) {
+      order = db.orders.find((row) =>
+        where.OR.some((condition: Record<string, string>) =>
+          orderMatchesFilter(row, condition)
+        )
+      );
+    } else {
+      order = db.orders.find(
+        (row) => row.userId === where.userId && row.status === where.status
+      );
+    }
+
+    if (!order) return Promise.resolve(null);
+    if (select?.id && !include) return Promise.resolve({ id: order.id });
+
+    return Promise.resolve(order);
+  });
+  tx.order.create.mockImplementation(({ data }) => {
+    const order: OrderRow = {
+      id: orderId,
+      userId: data.userId,
+      totalAmountCents: data.totalAmountCents,
+      subtotalAmountCents: data.subtotalAmountCents,
+      discountAmountCents: data.discountAmountCents,
+      taxAmountCents: data.taxAmountCents,
+      currency: data.currency,
+      status: data.status,
+      stripeCheckoutSessionId: null,
+      stripePaymentIntentId: null,
+      stripeCustomerId: null,
+      stripeInvoiceId: null,
+      stripeInvoiceUrl: null,
+      stripeReceiptUrl: null,
+      items: data.items.create.map(
+        (
+          item: {
+            itemId: string;
+            itemType: ItemType;
+            priceAtPurchaseCents: number;
+            quantity: number;
+          },
+          index: number
+        ) => ({
+          id: `order-item-${index + 1}`,
+          orderId,
+          ...item
+        })
+      )
+    };
+
+    db.orders.push(order);
+    return Promise.resolve({ id: order.id });
+  });
+  tx.order.update.mockImplementation(updateOrder);
+  tx.userWorkshop.upsert.mockResolvedValue({});
+}
+
+async function createCheckoutThenWebhook(
+  paymentStatus: Stripe.Checkout.Session['payment_status']
+) {
+  stripeConstructEventMock.mockReturnValue(checkoutSessionEvent(paymentStatus));
+
+  const checkoutResponse = await createCheckoutSession(createCheckoutRequest());
+
+  expect(checkoutResponse.status).toBe(201);
+
+  return receiveStripeWebhook(createWebhookRequest());
+}
+
+describe('checkout to Stripe webhook flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_flow_test';
+    resetFlowState();
+    installPrismaBehavior();
+
+    (auth as unknown as Mock).mockResolvedValue({ userId: clerkUserId });
+    stripeSessionCreateMock.mockResolvedValue({
+      id: checkoutSessionId,
+      url: 'https://checkout.stripe.test/flow-session'
+    });
+    stripePaymentIntentRetrieveMock.mockResolvedValue({
+      latest_charge: {
+        receipt_url: 'https://stripe.test/flow-receipt'
+      }
+    });
+    stripeInvoiceRetrieveMock.mockResolvedValue({
+      hosted_invoice_url: 'https://stripe.test/flow-invoice'
+    });
+    stripePromotionCodesListMock.mockResolvedValue({ data: [] });
+  });
+
+  it('creates checkout and completes the order from a paid webhook', async () => {
+    const webhookResponse = await createCheckoutThenWebhook('paid');
+    const order = db.orders[0];
+
+    expect(webhookResponse.status).toBe(200);
+    expect(await webhookResponse.json()).toEqual({
+      received: true,
+      fulfillment: {
+        orderId,
+        status: 'completed'
+      }
+    });
+    expect(order.status).toBe(OrderStatus.COMPLETED);
+    expect(order.stripeCheckoutSessionId).toBe(checkoutSessionId);
+    expect(order.stripePaymentIntentId).toBe('pi_flow_123');
+    expect(order.stripeCustomerId).toBe('cus_flow_123');
+    expect(order.stripeInvoiceId).toBe('in_flow_123');
+    expect(order.stripeInvoiceUrl).toBe('https://stripe.test/flow-invoice');
+    expect(order.stripeReceiptUrl).toBe('https://stripe.test/flow-receipt');
+    expect(order.items.map((item) => item.itemId)).toEqual([
+      videoDbId,
+      ebookDbId
+    ]);
+    expect(db.carts).toEqual([]);
+    expect(tx.cart.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId,
+        OR: expect.arrayContaining([
+          { itemId: videoDbId, itemType: ItemType.VIDEO },
+          { itemId: videoExternalId, itemType: ItemType.VIDEO },
+          { itemId: ebookDbId, itemType: ItemType.EBOOK },
+          { itemId: ebookExternalId, itemType: ItemType.EBOOK }
+        ])
+      }
+    });
+  });
+
+  it('keeps the order pending and cart intact for an unpaid webhook', async () => {
+    const webhookResponse = await createCheckoutThenWebhook('unpaid');
+    const order = db.orders[0];
+
+    expect(webhookResponse.status).toBe(200);
+    expect(await webhookResponse.json()).toEqual({
+      received: true,
+      fulfillment: {
+        orderId,
+        status: 'ignored'
+      }
+    });
+    expect(order.status).toBe(OrderStatus.PENDING);
+    expect(db.carts).toHaveLength(2);
+    expect(tx.cart.deleteMany).not.toHaveBeenCalled();
+    expect(tx.order.update).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: OrderStatus.COMPLETED })
+      })
+    );
+  });
+
+  it('treats a repeated paid webhook as already completed without cleanup side effects', async () => {
+    const firstWebhookResponse = await createCheckoutThenWebhook('paid');
+
+    expect(firstWebhookResponse.status).toBe(200);
+    await firstWebhookResponse.json();
+    expect(db.orders[0].status).toBe(OrderStatus.COMPLETED);
+
+    tx.cart.deleteMany.mockClear();
+    tx.video.findMany.mockClear();
+    tx.ebook.findMany.mockClear();
+
+    stripeConstructEventMock.mockReturnValue(checkoutSessionEvent('paid'));
+
+    const secondWebhookResponse = await receiveStripeWebhook(
+      createWebhookRequest()
+    );
+
+    expect(secondWebhookResponse.status).toBe(200);
+    expect(await secondWebhookResponse.json()).toEqual({
+      received: true,
+      fulfillment: {
+        orderId,
+        status: 'already_completed'
+      }
+    });
+    expect(tx.cart.deleteMany).not.toHaveBeenCalled();
+    expect(tx.video.findMany).not.toHaveBeenCalled();
+    expect(tx.ebook.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type Stripe from 'stripe';
+
+const constructEventMock = vi.fn();
+const fulfillCheckoutSessionMock = vi.fn();
+const stripeClientMock = {
+  webhooks: {
+    constructEvent: constructEventMock
+  }
+};
+
+vi.mock('@/lib/stripe', () => ({
+  getStripeClient: vi.fn(() => stripeClientMock)
+}));
+
+vi.mock('@/lib/stripe-fulfillment', () => ({
+  fulfillCheckoutSession: fulfillCheckoutSessionMock
+}));
+
+const { POST } = await import('./route');
+
+function request(headers: Record<string, string> = {}) {
+  return new Request('http://localhost:3000/api/stripe/webhook', {
+    method: 'POST',
+    headers,
+    body: '{"id":"evt_test_123"}'
+  });
+}
+
+describe('POST /api/stripe/webhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_test_123';
+    fulfillCheckoutSessionMock.mockResolvedValue({
+      orderId: 'order-123',
+      status: 'completed'
+    });
+    constructEventMock.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_test_123'
+        }
+      }
+    } as unknown as Stripe.Event);
+  });
+
+  it('rejects requests without a Stripe signature', async () => {
+    const response = await POST(request());
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Missing Stripe signature'
+    });
+    expect(constructEventMock).not.toHaveBeenCalled();
+    expect(fulfillCheckoutSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('verifies the webhook event and fulfills checkout sessions', async () => {
+    const response = await POST(
+      request({ 'stripe-signature': 'valid-signature' })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      received: true,
+      fulfillment: {
+        orderId: 'order-123',
+        status: 'completed'
+      }
+    });
+    expect(constructEventMock).toHaveBeenCalledWith(
+      '{"id":"evt_test_123"}',
+      'valid-signature',
+      'whsec_test_123'
+    );
+    expect(fulfillCheckoutSessionMock).toHaveBeenCalledWith(stripeClientMock, {
+      id: 'cs_test_123'
+    });
+  });
+
+  it('rejects invalid Stripe signatures', async () => {
+    constructEventMock.mockImplementation(() => {
+      throw new Error('Invalid signature');
+    });
+
+    const response = await POST(
+      request({ 'stripe-signature': 'bad-signature' })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'Invalid signature'
+    });
+    expect(fulfillCheckoutSessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/stripe/webhook/route.test.ts
+++ b/src/app/api/stripe/webhook/route.test.ts
@@ -36,6 +36,7 @@ describe('POST /api/stripe/webhook', () => {
       status: 'completed'
     });
     constructEventMock.mockReturnValue({
+      id: 'evt_test_123',
       type: 'checkout.session.completed',
       data: {
         object: {
@@ -93,5 +94,62 @@ describe('POST /api/stripe/webhook', () => {
       error: 'Invalid signature'
     });
     expect(fulfillCheckoutSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('logs configuration failures before signature verification', async () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    try {
+      const response = await POST(
+        request({ 'stripe-signature': 'valid-signature' })
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: 'Missing STRIPE_WEBHOOK_SECRET configuration'
+      });
+      expect(constructEventMock).not.toHaveBeenCalled();
+      expect(fulfillCheckoutSessionMock).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[API ERROR] POST /api/stripe/webhook: configuration failed',
+        {
+          error: expect.any(Error)
+        }
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('logs fulfillment failures before returning a server error', async () => {
+    const error = new Error('Fulfillment failed');
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    fulfillCheckoutSessionMock.mockRejectedValue(error);
+
+    try {
+      const response = await POST(
+        request({ 'stripe-signature': 'valid-signature' })
+      );
+
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({
+        error: 'Fulfillment failed'
+      });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[API ERROR] POST /api/stripe/webhook: fulfillment failed',
+        {
+          eventId: 'evt_test_123',
+          eventType: 'checkout.session.completed',
+          error
+        }
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -15,6 +15,18 @@ function webhookSecret() {
   return secret;
 }
 
+function logStripeWebhookError(
+  context: string,
+  error: unknown,
+  details: Record<string, string | undefined> = {}
+) {
+  // eslint-disable-next-line no-console
+  console.error(`[API ERROR] POST /api/stripe/webhook: ${context}`, {
+    ...details,
+    error
+  });
+}
+
 export async function POST(req: Request) {
   const signature = req.headers.get('stripe-signature');
 
@@ -37,6 +49,8 @@ export async function POST(req: Request) {
       error instanceof Error
         ? error.message
         : 'Stripe webhook is not configured';
+
+    logStripeWebhookError('configuration failed', error);
 
     return NextResponse.json({ error: message }, { status: 500 });
   }
@@ -66,6 +80,11 @@ export async function POST(req: Request) {
   } catch (error) {
     const message =
       error instanceof Error ? error.message : 'Failed to fulfill checkout';
+
+    logStripeWebhookError('fulfillment failed', error, {
+      eventId: event.id,
+      eventType: event.type
+    });
 
     return NextResponse.json({ error: message }, { status: 500 });
   }

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import type Stripe from 'stripe';
+import { fulfillCheckoutSession } from '@/lib/stripe-fulfillment';
+import { getStripeClient } from '@/lib/stripe';
+
+export const runtime = 'nodejs';
+
+function webhookSecret() {
+  const secret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
+
+  if (!secret) {
+    throw new Error('Missing STRIPE_WEBHOOK_SECRET configuration');
+  }
+
+  return secret;
+}
+
+export async function POST(req: Request) {
+  const signature = req.headers.get('stripe-signature');
+
+  if (!signature) {
+    return NextResponse.json(
+      { error: 'Missing Stripe signature' },
+      { status: 400 }
+    );
+  }
+
+  let stripe: Stripe;
+  let secret: string;
+  let event: Stripe.Event;
+
+  try {
+    stripe = getStripeClient();
+    secret = webhookSecret();
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Stripe webhook is not configured';
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  try {
+    const payload = await req.text();
+    event = stripe.webhooks.constructEvent(payload, signature, secret);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Invalid Stripe webhook payload';
+
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  try {
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const fulfillment = await fulfillCheckoutSession(stripe, session);
+
+      return NextResponse.json({
+        received: true,
+        fulfillment
+      });
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to fulfill checkout';
+
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/videos/[videoId]/route.test.ts
+++ b/src/app/api/videos/[videoId]/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const prismaMock = {
+  video: {
+    findUnique: vi.fn()
+  },
+  user: {
+    findUnique: vi.fn()
+  },
+  orderItem: {
+    findFirst: vi.fn()
+  }
+};
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const { GET } = await import('./route');
+
+function context(videoId = 'abc123') {
+  return {
+    params: Promise.resolve({ videoId })
+  };
+}
+
+describe('GET /api/videos/[videoId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk_user_123' } as never);
+    prismaMock.video.findUnique.mockResolvedValue({
+      id: 'video-db-123',
+      videoId: 'abc123',
+      title: 'Paid Video',
+      price: null,
+      courseId: 'course-123',
+      course: {
+        id: 'course-123',
+        price: '49.99'
+      }
+    });
+    prismaMock.user.findUnique.mockResolvedValue({ id: 'user-123' });
+    prismaMock.orderItem.findFirst.mockResolvedValue({
+      id: 'order-item-123'
+    });
+  });
+
+  it('returns paid video details for completed purchasers', async () => {
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      id: 'video-db-123',
+      videoId: 'abc123'
+    });
+    expect(prismaMock.orderItem.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          {
+            itemId: 'video-db-123',
+            itemType: ItemType.VIDEO
+          },
+          {
+            itemId: 'course-123',
+            itemType: ItemType.COURSE
+          }
+        ],
+        order: {
+          userId: 'user-123',
+          status: OrderStatus.COMPLETED
+        }
+      },
+      select: { id: true }
+    });
+  });
+
+  it('blocks paid videos for users without completed purchases', async () => {
+    prismaMock.orderItem.findFirst.mockResolvedValue(null);
+
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'Purchase required to view this video'
+    });
+  });
+
+  it('allows free videos without authentication', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+    prismaMock.video.findUnique.mockResolvedValue({
+      id: 'video-db-123',
+      videoId: 'abc123',
+      title: 'Free Video',
+      price: 0,
+      courseId: null,
+      course: null
+    });
+
+    const response = await GET(new Request('http://localhost'), context());
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.orderItem.findFirst).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/videos/[videoId]/route.ts
+++ b/src/app/api/videos/[videoId]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
 import prisma from '@/lib/prisma';
+import { findUserIdByClerkId, userCanAccessVideo } from '@/lib/entitlements';
 
 export async function GET(
   request: Request,
@@ -7,6 +9,7 @@ export async function GET(
 ) {
   try {
     const { videoId } = await params;
+    const { userId: clerkUserId } = await auth();
 
     // Validate video ID format
     if (!/^[a-zA-Z0-9]+$/.test(videoId)) {
@@ -17,11 +20,31 @@ export async function GET(
     }
 
     const video = await prisma.video.findUnique({
-      where: { videoId: videoId }
+      where: { videoId: videoId },
+      include: {
+        course: {
+          select: {
+            id: true,
+            price: true
+          }
+        }
+      }
     });
 
     if (!video) {
       return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+    }
+
+    const userId = clerkUserId
+      ? await findUserIdByClerkId(prisma, clerkUserId)
+      : null;
+    const canAccessVideo = await userCanAccessVideo(prisma, userId, video);
+
+    if (!canAccessVideo) {
+      return NextResponse.json(
+        { error: 'Purchase required to view this video' },
+        { status: 403 }
+      );
     }
 
     return NextResponse.json(video, { status: 200 });

--- a/src/components/admin/ebooks/actions/ebook-actions.ts
+++ b/src/components/admin/ebooks/actions/ebook-actions.ts
@@ -83,7 +83,7 @@ export async function createEbook(data: EbookData) {
     });
 
     revalidatePath('/admin/ebooks');
-  } catch (e) {
+  } catch {
     throw new Error('Failed to create ebook');
   }
   redirect('/admin/ebooks');

--- a/src/components/common/detail-hero-section.tsx
+++ b/src/components/common/detail-hero-section.tsx
@@ -2,7 +2,6 @@
 import { Heart } from 'lucide-react';
 import { Button } from '../ui/button';
 import { ItemType } from '@prisma/client';
-import { resolveImageSrc } from '@/lib/utils';
 
 interface DetailHeroSectionProps {
   backgroundImage?: string;

--- a/src/components/features/course/video-detail-container.tsx
+++ b/src/components/features/course/video-detail-container.tsx
@@ -155,6 +155,11 @@ export default function VideoDetailContainer({
       return;
     }
 
+    if (data?.entitlements?.canAccessCourse) {
+      showAlert('이미 구매한 콘텐츠', '구매내역에서 바로 수강할 수 있습니다.');
+      return;
+    }
+
     if (isInCart) {
       router.push('/mypage/cart');
       return;
@@ -196,11 +201,11 @@ export default function VideoDetailContainer({
 
         if (result.success) {
           setData(result.data);
-          // Set the first video as the selected media
-          const firstSection = result.data.course.sections[0];
-          if (firstSection && firstSection.videos.length > 0) {
-            setSelectedMediaId(firstSection.videos[0].videoId);
-          }
+          const firstAccessibleVideo = result.data.course.sections
+            .flatMap((section) => section.videos)
+            .find((video) => video.canAccessVideo && video.videoId);
+
+          setSelectedMediaId(firstAccessibleVideo?.videoId || '');
         } else {
           setError(result.message || '데이터를 불러오는데 실패했습니다.');
         }
@@ -296,6 +301,18 @@ export default function VideoDetailContainer({
           type: course.type,
           thumbnail: course.thumbnail
         })) || [];
+  const canAccessCourse = Boolean(data.entitlements?.canAccessCourse);
+  const requiresPurchase = Boolean(data.entitlements?.requiresPurchase);
+  const accessibleVideos = data.course.sections
+    .flatMap((section) => section.videos)
+    .filter((video) => video.canAccessVideo && video.videoId);
+  const hasAccessibleVideos = accessibleVideos.length > 0;
+
+  const heroButtonText = canAccessCourse
+    ? 'Purchased'
+    : isInCart
+      ? 'Go to Cart'
+      : 'Add to Cart';
 
   return (
     <div className="flex flex-col w-full h-full relative">
@@ -316,17 +333,22 @@ export default function VideoDetailContainer({
         onAddToCart={handleAddToCart}
         onToggleLike={handleToggleLike}
         isLiked={isLiked}
-        buttonText={isInCart ? 'Go to Cart' : 'Add to Cart'}
+        buttonText={heroButtonText}
         itemType={ItemType.COURSE}
       />
 
       <div className="w-full max-w-[1240px] px-5 py-24 mx-auto flex flex-col gap-24">
-        {isSignedIn && selectedMediaId && (
+        {isSignedIn && hasAccessibleVideos && selectedMediaId && (
           <div className="w-full aspect-video bg-black rounded-xl overflow-hidden shadow-2xl relative">
             <WistiaPlayer
               mediaId={selectedMediaId}
               id="wistia-player-container-1"
             />
+          </div>
+        )}
+        {isSignedIn && requiresPurchase && !hasAccessibleVideos && (
+          <div className="rounded-lg border border-pace-gray-100 bg-pace-gray-50 px-6 py-5 text-center text-pace-stone-600">
+            구매 완료 후 강의를 수강할 수 있습니다.
           </div>
         )}
 
@@ -453,7 +475,7 @@ export default function VideoDetailContainer({
         />
       </div>
 
-      {isSignedIn && !isPlaylistOpen && (
+      {isSignedIn && hasAccessibleVideos && !isPlaylistOpen && (
         <button
           type="button"
           onClick={() => setIsPlaylistOpen(true)}
@@ -525,24 +547,42 @@ export default function VideoDetailContainer({
                     >
                       <div className="border-t border-pace-gray-100 bg-pace-gray-50/50">
                         {section.videos.map((video) => {
-                          const isActive = video.videoId === selectedMediaId;
+                          const canAccessVideo = Boolean(
+                            video.canAccessVideo && video.videoId
+                          );
+                          const isActive =
+                            canAccessVideo && video.videoId === selectedMediaId;
                           return (
                             <button
-                              key={video.videoId}
+                              key={video.id}
                               type="button"
                               onClick={() => {
+                                if (!canAccessVideo) {
+                                  showAlert(
+                                    '구매가 필요한 영상',
+                                    '구매 완료 후 수강할 수 있습니다.'
+                                  );
+                                  return;
+                                }
+
                                 setSelectedMediaId(video.videoId);
                                 setIsPlaylistOpen(false);
                               }}
                               className={`w-full text-left px-4 py-3 transition-colors flex items-center gap-2 justify-between ${
                                 isActive
                                   ? 'bg-pace-base/10 border-l-4 border-pace-base text-pace-base'
-                                  : 'hover:bg-white text-pace-stone-700'
+                                  : canAccessVideo
+                                    ? 'hover:bg-white text-pace-stone-700'
+                                    : 'cursor-not-allowed text-pace-stone-300'
                               }`}
                             >
                               <div
                                 className={`size-2 rounded-full flex items-center justify-center flex-shrink-0  ${
-                                  isActive ? 'bg-pace-base' : 'bg-pace-gray-300'
+                                  isActive
+                                    ? 'bg-pace-base'
+                                    : canAccessVideo
+                                      ? 'bg-pace-gray-300'
+                                      : 'bg-pace-gray-100'
                                 }`}
                               />
                               <span className="text-sm font-medium truncate w-full">

--- a/src/components/features/ebook/pdf-viewer.tsx
+++ b/src/components/features/ebook/pdf-viewer.tsx
@@ -48,6 +48,13 @@ export default function PdfViewer({ ebookId, bucketName }: PdfViewerProps) {
           }
         });
 
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error(
+            data?.error || 'PDF를 불러올 권한을 확인하지 못했습니다.'
+          );
+        }
+
         const blob = await response.blob();
         const url = URL.createObjectURL(blob);
         setPdfUrl(url);

--- a/src/lib/__tests__/entitlements.test.ts
+++ b/src/lib/__tests__/entitlements.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+
+const client = {
+  user: {
+    findUnique: vi.fn()
+  },
+  orderItem: {
+    findFirst: vi.fn(),
+    findMany: vi.fn()
+  },
+  course: {},
+  ebook: {},
+  video: {}
+};
+
+const {
+  findUserIdByClerkId,
+  getAccessibleCourseVideoIds,
+  hasCompletedPurchase,
+  isFreePrice,
+  userCanAccessCourse,
+  userCanAccessEbook,
+  userCanAccessVideo
+} = await import('../entitlements');
+
+describe('entitlement helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('treats empty, missing, and zero prices as free', () => {
+    expect(isFreePrice(null)).toBe(true);
+    expect(isFreePrice('')).toBe(true);
+    expect(isFreePrice('0')).toBe(true);
+    expect(isFreePrice(0)).toBe(true);
+    expect(isFreePrice('문의')).toBe(false);
+    expect(isFreePrice(Number.NaN)).toBe(false);
+    expect(isFreePrice('49.99')).toBe(false);
+  });
+
+  it('resolves app user ids from Clerk ids', async () => {
+    client.user.findUnique.mockResolvedValue({ id: 'user-123' });
+
+    await expect(
+      findUserIdByClerkId(client as never, 'clerk_user_123')
+    ).resolves.toBe('user-123');
+  });
+
+  it('checks completed purchases by item type and id', async () => {
+    client.orderItem.findFirst.mockResolvedValue({ id: 'order-item-123' });
+
+    await expect(
+      hasCompletedPurchase(
+        client as never,
+        'user-123',
+        ItemType.EBOOK,
+        'ebook-123'
+      )
+    ).resolves.toBe(true);
+    expect(client.orderItem.findFirst).toHaveBeenCalledWith({
+      where: {
+        itemId: 'ebook-123',
+        itemType: ItemType.EBOOK,
+        order: {
+          userId: 'user-123',
+          status: OrderStatus.COMPLETED
+        }
+      },
+      select: { id: true }
+    });
+  });
+
+  it('allows paid course access only when a course purchase exists', async () => {
+    client.orderItem.findFirst.mockResolvedValue({ id: 'order-item-123' });
+
+    await expect(
+      userCanAccessCourse(client as never, 'user-123', {
+        id: 'course-123',
+        price: '49.99'
+      })
+    ).resolves.toBe(true);
+    expect(client.orderItem.findFirst).toHaveBeenCalledWith({
+      where: {
+        itemId: 'course-123',
+        itemType: ItemType.COURSE,
+        order: {
+          userId: 'user-123',
+          status: OrderStatus.COMPLETED
+        }
+      },
+      select: { id: true }
+    });
+  });
+
+  it('returns only individually purchased videos when the full course is not purchased', async () => {
+    client.orderItem.findFirst.mockResolvedValue(null);
+    client.orderItem.findMany.mockResolvedValue([{ itemId: 'video-123' }]);
+
+    const accessibleVideoIds = await getAccessibleCourseVideoIds(
+      client as never,
+      'user-123',
+      { id: 'course-123', price: '49.99' },
+      ['video-123', 'video-456']
+    );
+
+    expect([...accessibleVideoIds]).toEqual(['video-123']);
+    expect(client.orderItem.findMany).toHaveBeenCalledWith({
+      where: {
+        itemId: { in: ['video-123', 'video-456'] },
+        itemType: ItemType.VIDEO,
+        order: {
+          userId: 'user-123',
+          status: OrderStatus.COMPLETED
+        }
+      },
+      select: { itemId: true }
+    });
+  });
+
+  it('blocks paid ebook access without a completed purchase', async () => {
+    client.orderItem.findFirst.mockResolvedValue(null);
+
+    await expect(
+      userCanAccessEbook(client as never, 'user-123', {
+        id: 'ebook-123',
+        price: 25
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('allows paid video access when the parent course was purchased', async () => {
+    client.orderItem.findFirst.mockResolvedValue({ id: 'order-item-123' });
+
+    await expect(
+      userCanAccessVideo(client as never, 'user-123', {
+        id: 'video-123',
+        price: null,
+        courseId: 'course-123',
+        course: {
+          id: 'course-123',
+          price: '49.99'
+        }
+      })
+    ).resolves.toBe(true);
+    expect(client.orderItem.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          {
+            itemId: 'video-123',
+            itemType: ItemType.VIDEO
+          },
+          {
+            itemId: 'course-123',
+            itemType: ItemType.COURSE
+          }
+        ],
+        order: {
+          userId: 'user-123',
+          status: OrderStatus.COMPLETED
+        }
+      },
+      select: { id: true }
+    });
+  });
+});

--- a/src/lib/__tests__/stripe-fulfillment.test.ts
+++ b/src/lib/__tests__/stripe-fulfillment.test.ts
@@ -14,10 +14,10 @@ const tx = {
     deleteMany: vi.fn()
   },
   video: {
-    findUnique: vi.fn()
+    findMany: vi.fn()
   },
   ebook: {
-    findUnique: vi.fn()
+    findMany: vi.fn()
   }
 };
 
@@ -111,8 +111,18 @@ describe('fulfillCheckoutSession', () => {
     tx.order.update.mockResolvedValue({});
     tx.userWorkshop.upsert.mockResolvedValue({});
     tx.cart.deleteMany.mockResolvedValue({ count: 3 });
-    tx.video.findUnique.mockResolvedValue({ videoId: 'wistia_video_123' });
-    tx.ebook.findUnique.mockResolvedValue({ ebookId: 'ebook-file.pdf' });
+    tx.video.findMany.mockResolvedValue([
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        videoId: 'wistia_video_123'
+      }
+    ]);
+    tx.ebook.findMany.mockResolvedValue([
+      {
+        id: '55555555-5555-4555-8555-555555555555',
+        ebookId: 'ebook-file.pdf'
+      }
+    ]);
   });
 
   it('marks paid checkout orders complete and grants fulfillment side effects', async () => {
@@ -149,6 +159,18 @@ describe('fulfillCheckoutSession', () => {
         workshopId: '66666666-6666-4666-8666-666666666666',
         orderId: '22222222-2222-4222-8222-222222222222'
       }
+    });
+    expect(tx.video.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['44444444-4444-4444-8444-444444444444'] }
+      },
+      select: { id: true, videoId: true }
+    });
+    expect(tx.ebook.findMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ['55555555-5555-4555-8555-555555555555'] }
+      },
+      select: { id: true, ebookId: true }
     });
     expect(tx.cart.deleteMany).toHaveBeenCalledWith({
       where: {
@@ -262,5 +284,75 @@ describe('fulfillCheckoutSession', () => {
     const updateData = tx.order.update.mock.calls[0][0].data;
     expect(updateData).not.toHaveProperty('stripeInvoiceUrl');
     expect(updateData).not.toHaveProperty('stripeReceiptUrl');
+  });
+
+  it('does not query video or ebook aliases when order has only workshops', async () => {
+    tx.order.findFirst.mockResolvedValue({
+      ...pendingOrder(),
+      items: [
+        {
+          id: 'item-workshop',
+          itemId: '66666666-6666-4666-8666-666666666666',
+          itemType: ItemType.WORKSHOP
+        }
+      ]
+    });
+
+    const result = await fulfillCheckoutSession(
+      stripeMock(),
+      checkoutSession()
+    );
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'completed'
+    });
+    expect(tx.video.findMany).not.toHaveBeenCalled();
+    expect(tx.ebook.findMany).not.toHaveBeenCalled();
+    expect(tx.cart.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: '33333333-3333-4333-8333-333333333333',
+        OR: [
+          {
+            itemId: '66666666-6666-4666-8666-666666666666',
+            itemType: ItemType.WORKSHOP
+          }
+        ]
+      }
+    });
+  });
+
+  it('falls back to canonical order item ids when alias lookups miss', async () => {
+    tx.video.findMany.mockResolvedValue([]);
+    tx.ebook.findMany.mockResolvedValue([]);
+
+    const result = await fulfillCheckoutSession(
+      stripeMock(),
+      checkoutSession()
+    );
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'completed'
+    });
+    expect(tx.cart.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: '33333333-3333-4333-8333-333333333333',
+        OR: [
+          {
+            itemId: '44444444-4444-4444-8444-444444444444',
+            itemType: ItemType.VIDEO
+          },
+          {
+            itemId: '55555555-5555-4555-8555-555555555555',
+            itemType: ItemType.EBOOK
+          },
+          {
+            itemId: '66666666-6666-4666-8666-666666666666',
+            itemType: ItemType.WORKSHOP
+          }
+        ]
+      }
+    });
   });
 });

--- a/src/lib/__tests__/stripe-fulfillment.test.ts
+++ b/src/lib/__tests__/stripe-fulfillment.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ItemType, OrderStatus } from '@prisma/client';
+import type Stripe from 'stripe';
+
+const tx = {
+  order: {
+    findFirst: vi.fn(),
+    update: vi.fn()
+  },
+  userWorkshop: {
+    upsert: vi.fn()
+  },
+  cart: {
+    deleteMany: vi.fn()
+  },
+  video: {
+    findUnique: vi.fn()
+  },
+  ebook: {
+    findUnique: vi.fn()
+  }
+};
+
+const prismaMock = {
+  $transaction: vi.fn()
+};
+
+vi.mock('../prisma', () => ({
+  default: prismaMock
+}));
+
+const { fulfillCheckoutSession } = await import('../stripe-fulfillment');
+
+function stripeMock() {
+  return {
+    paymentIntents: {
+      retrieve: vi.fn().mockResolvedValue({
+        latest_charge: {
+          receipt_url: 'https://stripe.test/receipt'
+        }
+      })
+    },
+    invoices: {
+      retrieve: vi.fn().mockResolvedValue({
+        hosted_invoice_url: 'https://stripe.test/invoice'
+      })
+    }
+  } as unknown as Stripe;
+}
+
+function checkoutSession(
+  overrides: Partial<Stripe.Checkout.Session> = {}
+): Stripe.Checkout.Session {
+  return {
+    id: 'cs_test_123',
+    client_reference_id: '22222222-2222-4222-8222-222222222222',
+    metadata: {
+      orderId: '22222222-2222-4222-8222-222222222222'
+    },
+    payment_status: 'paid',
+    amount_subtotal: 10000,
+    amount_total: 8500,
+    total_details: {
+      amount_discount: 1500,
+      amount_shipping: 0,
+      amount_tax: 0
+    },
+    currency: 'cad',
+    payment_intent: 'pi_test_123',
+    customer: 'cus_test_123',
+    invoice: 'in_test_123',
+    ...overrides
+  } as Stripe.Checkout.Session;
+}
+
+function pendingOrder() {
+  return {
+    id: '22222222-2222-4222-8222-222222222222',
+    userId: '33333333-3333-4333-8333-333333333333',
+    status: OrderStatus.PENDING,
+    stripeCheckoutSessionId: 'cs_test_123',
+    stripeReceiptUrl: null,
+    stripeInvoiceUrl: null,
+    items: [
+      {
+        id: 'item-video',
+        itemId: '44444444-4444-4444-8444-444444444444',
+        itemType: ItemType.VIDEO
+      },
+      {
+        id: 'item-ebook',
+        itemId: '55555555-5555-4555-8555-555555555555',
+        itemType: ItemType.EBOOK
+      },
+      {
+        id: 'item-workshop',
+        itemId: '66666666-6666-4666-8666-666666666666',
+        itemType: ItemType.WORKSHOP
+      }
+    ]
+  };
+}
+
+describe('fulfillCheckoutSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(tx)
+    );
+    tx.order.findFirst.mockResolvedValue(pendingOrder());
+    tx.order.update.mockResolvedValue({});
+    tx.userWorkshop.upsert.mockResolvedValue({});
+    tx.cart.deleteMany.mockResolvedValue({ count: 3 });
+    tx.video.findUnique.mockResolvedValue({ videoId: 'wistia_video_123' });
+    tx.ebook.findUnique.mockResolvedValue({ ebookId: 'ebook-file.pdf' });
+  });
+
+  it('marks paid checkout orders complete and grants fulfillment side effects', async () => {
+    const result = await fulfillCheckoutSession(
+      stripeMock(),
+      checkoutSession()
+    );
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'completed'
+    });
+    expect(tx.order.findFirst).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { id: '22222222-2222-4222-8222-222222222222' },
+          { stripeCheckoutSessionId: 'cs_test_123' }
+        ]
+      },
+      include: { items: true }
+    });
+    expect(tx.userWorkshop.upsert).toHaveBeenCalledWith({
+      where: {
+        userId_workshopId: {
+          userId: '33333333-3333-4333-8333-333333333333',
+          workshopId: '66666666-6666-4666-8666-666666666666'
+        }
+      },
+      update: {
+        orderId: '22222222-2222-4222-8222-222222222222'
+      },
+      create: {
+        userId: '33333333-3333-4333-8333-333333333333',
+        workshopId: '66666666-6666-4666-8666-666666666666',
+        orderId: '22222222-2222-4222-8222-222222222222'
+      }
+    });
+    expect(tx.cart.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: '33333333-3333-4333-8333-333333333333',
+        OR: expect.arrayContaining([
+          {
+            itemId: '44444444-4444-4444-8444-444444444444',
+            itemType: ItemType.VIDEO
+          },
+          { itemId: 'wistia_video_123', itemType: ItemType.VIDEO },
+          {
+            itemId: '55555555-5555-4555-8555-555555555555',
+            itemType: ItemType.EBOOK
+          },
+          { itemId: 'ebook-file.pdf', itemType: ItemType.EBOOK },
+          {
+            itemId: '66666666-6666-4666-8666-666666666666',
+            itemType: ItemType.WORKSHOP
+          }
+        ])
+      }
+    });
+    expect(tx.order.update).toHaveBeenCalledWith({
+      where: { id: '22222222-2222-4222-8222-222222222222' },
+      data: expect.objectContaining({
+        status: OrderStatus.COMPLETED,
+        stripeCheckoutSessionId: 'cs_test_123',
+        stripePaymentIntentId: 'pi_test_123',
+        stripeCustomerId: 'cus_test_123',
+        stripeInvoiceId: 'in_test_123',
+        stripeInvoiceUrl: 'https://stripe.test/invoice',
+        stripeReceiptUrl: 'https://stripe.test/receipt',
+        subtotalAmountCents: 10000,
+        discountAmountCents: 1500,
+        taxAmountCents: 0,
+        totalAmountCents: 8500,
+        currency: 'cad'
+      })
+    });
+  });
+
+  it('ignores unpaid completed checkout sessions', async () => {
+    const result = await fulfillCheckoutSession(
+      stripeMock(),
+      checkoutSession({ payment_status: 'unpaid' })
+    );
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'ignored'
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not duplicate side effects for already completed orders', async () => {
+    tx.order.findFirst.mockResolvedValue({
+      ...pendingOrder(),
+      status: OrderStatus.COMPLETED,
+      stripeReceiptUrl: 'https://stripe.test/receipt',
+      stripeInvoiceUrl: 'https://stripe.test/invoice'
+    });
+
+    const result = await fulfillCheckoutSession(
+      stripeMock(),
+      checkoutSession()
+    );
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'already_completed'
+    });
+    expect(tx.userWorkshop.upsert).not.toHaveBeenCalled();
+    expect(tx.cart.deleteMany).not.toHaveBeenCalled();
+    expect(tx.order.update).not.toHaveBeenCalled();
+  });
+
+  it('completes fulfillment when receipt and invoice lookups fail', async () => {
+    const stripe = stripeMock() as Stripe & {
+      paymentIntents: {
+        retrieve: ReturnType<typeof vi.fn>;
+      };
+      invoices: {
+        retrieve: ReturnType<typeof vi.fn>;
+      };
+    };
+    stripe.paymentIntents.retrieve.mockRejectedValue(
+      new Error('Stripe payment intent lookup failed')
+    );
+    stripe.invoices.retrieve.mockRejectedValue(
+      new Error('Stripe invoice lookup failed')
+    );
+
+    const result = await fulfillCheckoutSession(stripe, checkoutSession());
+
+    expect(result).toEqual({
+      orderId: '22222222-2222-4222-8222-222222222222',
+      status: 'completed'
+    });
+    expect(tx.userWorkshop.upsert).toHaveBeenCalled();
+    expect(tx.cart.deleteMany).toHaveBeenCalled();
+    expect(tx.order.update).toHaveBeenCalledWith({
+      where: { id: '22222222-2222-4222-8222-222222222222' },
+      data: expect.objectContaining({
+        status: OrderStatus.COMPLETED,
+        stripeCheckoutSessionId: 'cs_test_123',
+        stripePaymentIntentId: 'pi_test_123',
+        stripeCustomerId: 'cus_test_123',
+        stripeInvoiceId: 'in_test_123'
+      })
+    });
+    const updateData = tx.order.update.mock.calls[0][0].data;
+    expect(updateData).not.toHaveProperty('stripeInvoiceUrl');
+    expect(updateData).not.toHaveProperty('stripeReceiptUrl');
+  });
+});

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,0 +1,160 @@
+import { ItemType, OrderStatus, Prisma } from '@prisma/client';
+
+type EntitlementClient = Pick<
+  Prisma.TransactionClient,
+  'course' | 'ebook' | 'orderItem' | 'user' | 'video'
+>;
+
+export function isFreePrice(price: number | string | null | undefined) {
+  if (price === null || price === undefined || price === '') return true;
+
+  if (typeof price === 'number') {
+    return Number.isFinite(price) && price <= 0;
+  }
+
+  const normalized = price.trim().replace(/[^0-9.-]+/g, '');
+  if (!normalized) return false;
+
+  const amount = Number(normalized);
+  return Number.isFinite(amount) && amount <= 0;
+}
+
+export async function findUserIdByClerkId(
+  client: EntitlementClient,
+  clerkUserId: string
+) {
+  const user = await client.user.findUnique({
+    where: { clerkId: clerkUserId },
+    select: { id: true }
+  });
+
+  return user?.id ?? null;
+}
+
+export async function hasCompletedPurchase(
+  client: EntitlementClient,
+  userId: string,
+  itemType: ItemType,
+  itemId: string
+) {
+  const orderItem = await client.orderItem.findFirst({
+    where: {
+      itemId,
+      itemType,
+      order: {
+        userId,
+        status: OrderStatus.COMPLETED
+      }
+    },
+    select: { id: true }
+  });
+
+  return Boolean(orderItem);
+}
+
+export async function userCanAccessCourse(
+  client: EntitlementClient,
+  userId: string | null,
+  course: {
+    id: string;
+    price: string | null;
+  }
+) {
+  if (isFreePrice(course.price)) return true;
+  if (!userId) return false;
+
+  return hasCompletedPurchase(client, userId, ItemType.COURSE, course.id);
+}
+
+export async function getAccessibleCourseVideoIds(
+  client: EntitlementClient,
+  userId: string | null,
+  course: {
+    id: string;
+    price: string | null;
+  },
+  videoIds: string[]
+) {
+  if (!videoIds.length) return new Set<string>();
+
+  const canAccessFullCourse = await userCanAccessCourse(client, userId, course);
+
+  if (canAccessFullCourse) return new Set(videoIds);
+  if (!userId) return new Set<string>();
+
+  const orderItems = await client.orderItem.findMany({
+    where: {
+      itemId: { in: videoIds },
+      itemType: ItemType.VIDEO,
+      order: {
+        userId,
+        status: OrderStatus.COMPLETED
+      }
+    },
+    select: { itemId: true }
+  });
+
+  return new Set(orderItems.map((item) => item.itemId));
+}
+
+export async function userCanAccessEbook(
+  client: EntitlementClient,
+  userId: string | null,
+  ebook: {
+    id: string;
+    price: number | null;
+  }
+) {
+  if (isFreePrice(ebook.price)) return true;
+  if (!userId) return false;
+
+  return hasCompletedPurchase(client, userId, ItemType.EBOOK, ebook.id);
+}
+
+export async function userCanAccessVideo(
+  client: EntitlementClient,
+  userId: string | null,
+  video: {
+    id: string;
+    price: number | null;
+    courseId: string | null;
+    course?: {
+      id: string;
+      price: string | null;
+    } | null;
+  }
+) {
+  const requiresPurchase =
+    !isFreePrice(video.price) ||
+    Boolean(video.course && !isFreePrice(video.course.price));
+
+  if (!requiresPurchase) return true;
+  if (!userId) return false;
+
+  const purchaseFilters: Prisma.OrderItemWhereInput[] = [
+    {
+      itemId: video.id,
+      itemType: ItemType.VIDEO
+    }
+  ];
+
+  if (video.courseId) {
+    purchaseFilters.push({
+      itemId: video.courseId,
+      itemType: ItemType.COURSE
+    });
+  }
+
+  const orderItem = await client.orderItem.findFirst({
+    where: {
+      OR: purchaseFilters,
+      order: {
+        userId,
+        status: OrderStatus.COMPLETED
+      }
+    },
+    select: { id: true }
+  });
+
+  return Boolean(orderItem);
+}

--- a/src/lib/stripe-fulfillment.ts
+++ b/src/lib/stripe-fulfillment.ts
@@ -116,26 +116,46 @@ async function cartCleanupFilters(
   order: OrderWithItems
 ) {
   const filters: Prisma.CartWhereInput[] = [];
+  const videoItemIds = order.items
+    .filter((item) => item.itemType === ItemType.VIDEO)
+    .map((item) => item.itemId);
+  const ebookItemIds = order.items
+    .filter((item) => item.itemType === ItemType.EBOOK)
+    .map((item) => item.itemId);
+  const [videos, ebooks] = await Promise.all([
+    videoItemIds.length
+      ? tx.video.findMany({
+          where: { id: { in: videoItemIds } },
+          select: { id: true, videoId: true }
+        })
+      : Promise.resolve([] as { id: string; videoId: string }[]),
+    ebookItemIds.length
+      ? tx.ebook.findMany({
+          where: { id: { in: ebookItemIds } },
+          select: { id: true, ebookId: true }
+        })
+      : Promise.resolve([] as { id: string; ebookId: string }[])
+  ]);
+  const videoIdsById = new Map(
+    videos.map((video) => [video.id, video.videoId])
+  );
+  const ebookIdsById = new Map(
+    ebooks.map((ebook) => [ebook.id, ebook.ebookId])
+  );
 
   for (const item of order.items) {
     const itemIds = new Set([item.itemId]);
 
     if (item.itemType === ItemType.VIDEO) {
-      const video = await tx.video.findUnique({
-        where: { id: item.itemId },
-        select: { videoId: true }
-      });
+      const videoId = videoIdsById.get(item.itemId);
 
-      if (video?.videoId) itemIds.add(video.videoId);
+      if (videoId) itemIds.add(videoId);
     }
 
     if (item.itemType === ItemType.EBOOK) {
-      const ebook = await tx.ebook.findUnique({
-        where: { id: item.itemId },
-        select: { ebookId: true }
-      });
+      const ebookId = ebookIdsById.get(item.itemId);
 
-      if (ebook?.ebookId) itemIds.add(ebook.ebookId);
+      if (ebookId) itemIds.add(ebookId);
     }
 
     for (const itemId of itemIds) {

--- a/src/lib/stripe-fulfillment.ts
+++ b/src/lib/stripe-fulfillment.ts
@@ -1,0 +1,281 @@
+import { ItemType, OrderStatus, Prisma } from '@prisma/client';
+import type Stripe from 'stripe';
+import prisma from './prisma';
+
+type OrderWithItems = Prisma.OrderGetPayload<{
+  include: { items: true };
+}>;
+
+export type CheckoutFulfillmentResult = {
+  orderId: string | null;
+  status: 'completed' | 'already_completed' | 'ignored';
+};
+
+function stripeObjectId(
+  value: string | { id?: string } | null | undefined
+): string | null {
+  if (!value) return null;
+  if (typeof value === 'string') return value;
+  return typeof value.id === 'string' ? value.id : null;
+}
+
+function isPaidCheckoutSession(session: Stripe.Checkout.Session) {
+  return (
+    session.payment_status === 'paid' ||
+    session.payment_status === 'no_payment_required'
+  );
+}
+
+function sessionOrderId(session: Stripe.Checkout.Session) {
+  return session.metadata?.orderId || session.client_reference_id || null;
+}
+
+function compactUpdateData<T extends Record<string, unknown>>(data: T) {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== undefined)
+  ) as T;
+}
+
+function chargeReceiptUrl(paymentIntent: Stripe.PaymentIntent) {
+  const latestCharge = paymentIntent.latest_charge;
+
+  if (!latestCharge || typeof latestCharge === 'string') return null;
+  if ('deleted' in latestCharge && latestCharge.deleted) return null;
+
+  return latestCharge.receipt_url ?? null;
+}
+
+async function retrievePaymentIntentReceiptUrl(
+  stripe: Stripe,
+  paymentIntentId: string | null
+) {
+  if (!paymentIntentId) return null;
+
+  const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId, {
+    expand: ['latest_charge']
+  });
+
+  return chargeReceiptUrl(paymentIntent);
+}
+
+async function retrieveInvoiceUrl(stripe: Stripe, invoiceId: string | null) {
+  if (!invoiceId) return null;
+
+  const invoice = await stripe.invoices.retrieve(invoiceId);
+  return invoice.hosted_invoice_url ?? null;
+}
+
+async function resolveStripeReferences(
+  stripe: Stripe,
+  session: Stripe.Checkout.Session
+) {
+  const paymentIntentId = stripeObjectId(session.payment_intent);
+  const customerId = stripeObjectId(session.customer);
+  const invoiceId = stripeObjectId(session.invoice);
+  const expandedInvoiceUrl =
+    typeof session.invoice === 'object' && session.invoice
+      ? (session.invoice.hosted_invoice_url ?? null)
+      : null;
+  const [invoiceUrl, receiptUrl] = await Promise.all([
+    expandedInvoiceUrl
+      ? Promise.resolve(expandedInvoiceUrl)
+      : retrieveInvoiceUrl(stripe, invoiceId).catch(() => null),
+    retrievePaymentIntentReceiptUrl(stripe, paymentIntentId).catch(() => null)
+  ]);
+
+  return {
+    paymentIntentId,
+    customerId,
+    invoiceId,
+    invoiceUrl,
+    receiptUrl
+  };
+}
+
+function orderLookupWhere(session: Stripe.Checkout.Session) {
+  const conditions: Prisma.OrderWhereInput[] = [];
+  const orderId = sessionOrderId(session);
+
+  if (orderId) {
+    conditions.push({ id: orderId });
+  }
+
+  if (session.id) {
+    conditions.push({ stripeCheckoutSessionId: session.id });
+  }
+
+  if (!conditions.length) {
+    throw new Error('Stripe checkout session is missing order metadata');
+  }
+
+  return { OR: conditions };
+}
+
+async function cartCleanupFilters(
+  tx: Prisma.TransactionClient,
+  order: OrderWithItems
+) {
+  const filters: Prisma.CartWhereInput[] = [];
+
+  for (const item of order.items) {
+    const itemIds = new Set([item.itemId]);
+
+    if (item.itemType === ItemType.VIDEO) {
+      const video = await tx.video.findUnique({
+        where: { id: item.itemId },
+        select: { videoId: true }
+      });
+
+      if (video?.videoId) itemIds.add(video.videoId);
+    }
+
+    if (item.itemType === ItemType.EBOOK) {
+      const ebook = await tx.ebook.findUnique({
+        where: { id: item.itemId },
+        select: { ebookId: true }
+      });
+
+      if (ebook?.ebookId) itemIds.add(ebook.ebookId);
+    }
+
+    for (const itemId of itemIds) {
+      filters.push({
+        itemId,
+        itemType: item.itemType
+      });
+    }
+  }
+
+  return filters;
+}
+
+async function grantWorkshopRegistrations(
+  tx: Prisma.TransactionClient,
+  order: OrderWithItems
+) {
+  if (!order.userId) return;
+
+  const workshopItems = order.items.filter(
+    (item) => item.itemType === ItemType.WORKSHOP
+  );
+
+  for (const item of workshopItems) {
+    await tx.userWorkshop.upsert({
+      where: {
+        userId_workshopId: {
+          userId: order.userId,
+          workshopId: item.itemId
+        }
+      },
+      update: {
+        orderId: order.id
+      },
+      create: {
+        userId: order.userId,
+        workshopId: item.itemId,
+        orderId: order.id
+      }
+    });
+  }
+}
+
+async function removePurchasedCartItems(
+  tx: Prisma.TransactionClient,
+  order: OrderWithItems
+) {
+  if (!order.userId) return;
+
+  const filters = await cartCleanupFilters(tx, order);
+  if (!filters.length) return;
+
+  await tx.cart.deleteMany({
+    where: {
+      userId: order.userId,
+      OR: filters
+    }
+  });
+}
+
+export async function fulfillCheckoutSession(
+  stripe: Stripe,
+  session: Stripe.Checkout.Session
+): Promise<CheckoutFulfillmentResult> {
+  if (!isPaidCheckoutSession(session)) {
+    return {
+      orderId: sessionOrderId(session),
+      status: 'ignored'
+    };
+  }
+
+  const stripeReferences = await resolveStripeReferences(stripe, session);
+
+  return prisma.$transaction(async (tx) => {
+    const order = await tx.order.findFirst({
+      where: orderLookupWhere(session),
+      include: { items: true }
+    });
+
+    if (!order) {
+      throw new Error('Order not found for Stripe checkout session');
+    }
+
+    if (
+      order.stripeCheckoutSessionId &&
+      order.stripeCheckoutSessionId !== session.id
+    ) {
+      throw new Error('Stripe checkout session does not match the order');
+    }
+
+    if (order.status === OrderStatus.COMPLETED) {
+      const missingStripeData =
+        (!order.stripeReceiptUrl && stripeReferences.receiptUrl) ||
+        (!order.stripeInvoiceUrl && stripeReferences.invoiceUrl);
+
+      if (missingStripeData) {
+        await tx.order.update({
+          where: { id: order.id },
+          data: compactUpdateData({
+            stripePaymentIntentId:
+              stripeReferences.paymentIntentId ?? undefined,
+            stripeCustomerId: stripeReferences.customerId ?? undefined,
+            stripeInvoiceId: stripeReferences.invoiceId ?? undefined,
+            stripeInvoiceUrl: stripeReferences.invoiceUrl ?? undefined,
+            stripeReceiptUrl: stripeReferences.receiptUrl ?? undefined
+          })
+        });
+      }
+
+      return {
+        orderId: order.id,
+        status: 'already_completed'
+      };
+    }
+
+    await grantWorkshopRegistrations(tx, order);
+    await removePurchasedCartItems(tx, order);
+
+    await tx.order.update({
+      where: { id: order.id },
+      data: compactUpdateData({
+        status: OrderStatus.COMPLETED,
+        stripeCheckoutSessionId: session.id,
+        stripePaymentIntentId: stripeReferences.paymentIntentId ?? undefined,
+        stripeCustomerId: stripeReferences.customerId ?? undefined,
+        stripeInvoiceId: stripeReferences.invoiceId ?? undefined,
+        stripeInvoiceUrl: stripeReferences.invoiceUrl ?? undefined,
+        stripeReceiptUrl: stripeReferences.receiptUrl ?? undefined,
+        subtotalAmountCents: session.amount_subtotal ?? undefined,
+        discountAmountCents:
+          session.total_details?.amount_discount ?? undefined,
+        taxAmountCents: session.total_details?.amount_tax ?? undefined,
+        totalAmountCents: session.amount_total ?? undefined,
+        currency: session.currency ?? undefined
+      })
+    });
+
+    return {
+      orderId: order.id,
+      status: 'completed'
+    };
+  });
+}

--- a/src/types/video-detail.d.ts
+++ b/src/types/video-detail.d.ts
@@ -93,6 +93,7 @@ export interface ApiReview {
 export interface Video {
   id: string;
   videoId: string;
+  canAccessVideo?: boolean;
   title: string | null;
   description: string | null;
   price: number | null;
@@ -128,6 +129,10 @@ export interface ApiResponse {
   data: {
     course: Course;
     instructors: Instructor[];
+    entitlements?: {
+      requiresPurchase: boolean;
+      canAccessCourse: boolean;
+    };
   };
   error?: string;
   message?: string;


### PR DESCRIPTION
## Summary

Implements Stripe webhook fulfillment and purchase entitlements for paid content under PACE-261. This also covers the PACE-271 scope for purchase entitlements and paid content access control.

## Changes

- Added Stripe webhook endpoint for `checkout.session.completed`
- Added checkout fulfillment logic to mark paid orders as `COMPLETED`
- Stores Stripe payment/customer/invoice/receipt metadata when available
- Makes receipt/invoice URL lookup best-effort so fulfillment is not blocked by Stripe lookup failures
- Adds entitlement helpers for course, video, and ebook access
- Adds route-level access control for courses, videos, ebooks, and purchase status APIs
- Supports video-level access inside paid courses:
  - Course purchase unlocks all course videos
  - Individual video purchase unlocks only that video
- Updates course detail UI to hide locked video IDs and show purchase-required state
- Improves ebook PDF error handling
- Removes unused warning sources from admin/common components

## Testing

### Automated Checks

Run these from the project root:

```bash
npm run typecheck
npm test -- --run
npm run build
npm run validate-branch-name
```

Expected result:

- Typecheck passes without TypeScript errors
- Vitest passes with `96 passed` and `4 skipped`
- Production build completes successfully
- Build should not show the previous unused warnings
- Branch name validation passes

### Stripe Webhook Local Smoke Test

1. Start the app locally:

```bash
npm run dev
```

2. In another terminal, forward Stripe webhook events:

```bash
stripe listen --forward-to localhost:3000/api/stripe/webhook
```

3. Copy the webhook secret printed by Stripe CLI and set it in `.env.local`:

```bash
STRIPE_WEBHOOK_SECRET=whsec_...
```

4. Restart the dev server after updating `.env.local`.

5. Trigger a checkout session completed event:

```bash
stripe trigger checkout.session.completed
```

Expected result:

- The app receives the webhook without signature errors
- Unmatched mock Stripe sessions may return an order lookup error, which is OK for this CLI-generated event
- Real checkout sessions created by this app should mark the matching order as `COMPLETED`

### Manual App Flow

1. Sign in with a test user.
2. Add a paid course to cart.
3. Complete checkout with Stripe test card:

```text
4242 4242 4242 4242
```

Use any future expiry date, any CVC, and any postal code.

4. After payment, open the purchase history page.

Expected result:

- The order appears as completed after the webhook is processed
- Purchased course content is accessible
- Course purchase unlocks all videos in that course

### Video-Level Entitlement Check

1. Create or use a paid course with multiple videos.
2. Purchase only one individual video if that flow is available in the test data.
3. Open the course detail page.

Expected result:

- Only the purchased video is playable
- Other videos remain locked
- Buying the full course unlocks all course videos

### Access Control Checks

Try these while signed out:

- Open a paid course detail page
- Request a paid video API URL
- Open an ebook PDF URL
- Request `/api/purchase-video-status`

Expected result:

- Paid course page does not expose playable video IDs
- Paid video API returns blocked access
- Ebook PDF requires authentication
- Purchase status API requires authentication

## Notes

- Production Stripe live-mode rollout still requires live `STRIPE_SECRET_KEY` and live webhook secret in Vercel.
- PACE-271 scope is included in this PACE-261 implementation.