### PR TITLE
[PACE-290] Prevent locked course video ID leakage

### DIFF
--- a/docs/stripe-payment-implementation-plan.md
+++ b/docs/stripe-payment-implementation-plan.md
@@ -191,6 +191,16 @@ Notes:
 | PACE-260 | Checkout API, cart handoff, and post-payment UX   | Steps 2 and 4, plus checkout and post-payment UX test coverage.       |
 | PACE-261 | Webhook fulfillment, entitlements, and validation | Steps 3 and 5, plus webhook, entitlement, and operational validation. |
 
+Post-merge production follow-up priority as of 2026-06-29:
+
+| Priority | Jira Key | Summary                                                | Notes                                                                                                            |
+| -------- | -------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| 1        | PACE-290 | [Security] Course detail API exposes locked video IDs  | Highest-priority follow-up. Production API still exposes locked `sectionsRel[].videos[].videoId` values.         |
+| 2        | PACE-291 | [Bug] Ebook detail Add to cart button does nothing     | Purchase conversion bug on ebook detail. Fix after PACE-290 unless the launch plan reprioritizes ebook checkout. |
+| 3        | PACE-244 | [Security] Cart/Favorites/Interest API ownership check | Broader ownership-hardening work; important but less directly tied to the PACE-261 production follow-up.         |
+| 4        | PACE-245 | [Security] Public/private content exposure policy      | Broader content exposure policy audit; tackle after the confirmed course detail leak.                            |
+| 5        | PACE-292 | [Bug] Mobile course and ebook detail layout overflows  | Important visual regression; can be coordinated with the active redesign detail tickets.                         |
+
 Superseded tickets:
 
 | Old Jira Key | Merged Into  | Original Scope                           |

--- a/src/app/api/courses/detail/[id]/route.test.ts
+++ b/src/app/api/courses/detail/[id]/route.test.ts
@@ -125,6 +125,9 @@ describe('GET /api/courses/detail/[id]', () => {
     expect(data.data.course.videos[0].canAccessVideo).toBe(false);
     expect(data.data.course.sections[0].videos[0].videoId).toBe('');
     expect(data.data.course.sections[0].videos[0].canAccessVideo).toBe(false);
+    expect(data.data.course.sectionsRel).toBeUndefined();
+    expect(JSON.stringify(data.data.course)).not.toContain('wistia123');
+    expect(JSON.stringify(data.data.course)).not.toContain('wistia456');
   });
 
   it('keeps all playable video ids for completed course purchasers', async () => {
@@ -146,6 +149,7 @@ describe('GET /api/courses/detail/[id]', () => {
     expect(data.data.course.videos[1].videoId).toBe('wistia456');
     expect(data.data.course.videos[1].canAccessVideo).toBe(true);
     expect(data.data.course.sections[0].videos[0].videoId).toBe('wistia123');
+    expect(data.data.course.sectionsRel).toBeUndefined();
   });
 
   it('keeps only individually purchased video ids when the course is not purchased', async () => {
@@ -171,5 +175,27 @@ describe('GET /api/courses/detail/[id]', () => {
     expect(data.data.course.videos[1].canAccessVideo).toBe(true);
     expect(data.data.course.sections[0].videos[0].videoId).toBe('');
     expect(data.data.course.sections[0].videos[1].videoId).toBe('wistia456');
+    expect(data.data.course.sectionsRel).toBeUndefined();
+    expect(JSON.stringify(data.data.course)).not.toContain('wistia123');
+  });
+
+  it('keeps playable video ids for free courses without exposing raw sectionsRel', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+    prismaMock.course.findUnique.mockResolvedValue({
+      ...courseFixture(),
+      price: '0'
+    });
+
+    const response = await GET(new Request('http://localhost'), context());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.data.entitlements).toEqual({
+      requiresPurchase: false,
+      canAccessCourse: true
+    });
+    expect(data.data.course.videos[0].videoId).toBe('wistia123');
+    expect(data.data.course.sections[0].videos[0].videoId).toBe('wistia123');
+    expect(data.data.course.sectionsRel).toBeUndefined();
   });
 });

--- a/src/app/api/courses/detail/[id]/route.ts
+++ b/src/app/api/courses/detail/[id]/route.ts
@@ -212,13 +212,19 @@ export async function GET(
       }
     }
 
+    const {
+      videos: courseVideos,
+      sectionsRel: courseSections,
+      ...courseBase
+    } = courseData;
+
     // DB 구조를 Frontend 구조로 변환
     const course = {
-      ...courseData,
-      videos: courseData.videos.map((video) =>
+      ...courseBase,
+      videos: courseVideos.map((video) =>
         applyVideoEntitlement(video, accessibleVideoIds)
       ),
-      sections: (courseData.sectionsRel || []).map((section) => ({
+      sections: (courseSections || []).map((section) => ({
         ...section,
         videos: (section.videos || []).map((video) =>
           applyVideoEntitlement(video, accessibleVideoIds)


### PR DESCRIPTION
## Why this PR:

PACE-290 fixes a production follow-up from the Stripe entitlement rollout.

The course detail API was correctly sanitizing `course.sections`, but the raw Prisma relation `course.sectionsRel` was still included through `...courseData`. As a result, signed-out or unpurchased users could inspect the network response and see locked `videos[].videoId` values even though the UI and playback API were gated.

## Changes:

- Removed raw `sectionsRel` from the public course detail API response.
- Kept the existing sanitized response shape:
  - `course.videos`
  - `course.sections`
  - `canAccessVideo`
  - blank `videoId` for inaccessible videos
- Added regression coverage to ensure `sectionsRel` is not exposed.
- Added edge-case coverage for:
  - signed-out paid course users
  - completed course purchasers
  - individually purchased videos
  - free courses
- Documented the post-merge production follow-up priority list in the Stripe implementation plan.

## How to Test:

```bash
npm test -- --run 'src/app/api/courses/detail/[id]/route.test.ts' src/lib/__tests__/entitlements.test.ts 'src/app/api/videos/[videoId]/route.test.ts'
npm test -- --run
npm run build
npm run typecheck
```