### PR TITLE
test: mock Clerk auth in ebook detail page test

### DIFF
--- a/src/app/ebooks/[ebookId]/page.test.tsx
+++ b/src/app/ebooks/[ebookId]/page.test.tsx
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
 const prismaMock = {
   ebook: {
     findFirst: vi.fn(),
@@ -21,6 +25,7 @@ vi.mock('@/components/features/ebook/ebook-detail-container', () => ({
   default: vi.fn(() => null)
 }));
 
+const { auth } = await import('@clerk/nextjs/server');
 const { notFound } = await import('next/navigation');
 const { default: EbookDetailPage } = await import('./page');
 
@@ -33,6 +38,7 @@ function pageContext(ebookId = 'ebook-123') {
 describe('Ebook detail page visibility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
     prismaMock.ebook.findFirst.mockResolvedValue({
       title: 'Public Ebook',
       description: 'Ebook description',


### PR DESCRIPTION
## Summary
- mock Clerk server-side `auth()` in the ebook detail page test
- keep the public visibility policy test independent of the Clerk runtime

## Validation
- npm test -- --run
- npm run typecheck
- npm run build
- npm run lint