### PR TITLE
PACE-244 Enforce Cart, Favorites, and Interest API Ownership

### DIFF
--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { ItemType } from '@prisma/client';
+import { requireCurrentUserId } from '@/lib/current-user';
+import { apiErrorResponse, isItemType } from '@/lib/api-request';
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   try {
-    const userId = req.nextUrl.searchParams.get('userId');
-    if (!userId)
-      return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+    const userId = await requireCurrentUserId();
 
     const carts = await prisma.cart.findMany({
       where: { userId },
@@ -69,10 +69,7 @@ export async function GET(req: NextRequest) {
               break;
           }
         } catch (error) {
-          return NextResponse.json(
-            { error: `Item lookup failed: ${error}` },
-            { status: 500 }
-          );
+          throw new Error('Item lookup failed', { cause: error });
         }
 
         return { ...cart, ...item };
@@ -81,116 +78,112 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(detailedCarts);
   } catch (err) {
-    return NextResponse.json(
-      { error: `GET /api/cart error: ${err}` },
-      { status: 500 }
-    );
+    return apiErrorResponse(err, 'Failed to fetch cart');
   }
 }
 
 export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { userId, itemId, itemType } = body;
+  try {
+    const userId = await requireCurrentUserId();
+    const { itemId, itemType } = await req.json().catch(() => ({}));
 
-  if (!userId || !itemId || !itemType)
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    if (typeof itemId !== 'string' || !itemId.trim() || !isItemType(itemType))
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
 
-  const existing = await prisma.cart.findFirst({
-    where: { userId, itemId, itemType }
-  });
-
-  if (existing) {
-    return NextResponse.json(
-      { error: 'Item already exists in cart' },
-      { status: 409 }
-    );
-  }
-
-  const cart = await prisma.$transaction(async (tx) => {
-    const newCart = await tx.cart.create({
-      data: { userId, itemId, itemType }
+    const existing = await prisma.cart.findFirst({
+      where: { userId, itemId, itemType }
     });
-    let item = null;
 
-    try {
-      switch (newCart.itemType) {
-        case ItemType.VIDEO:
-          item = await prisma.video.findUnique({
-            where: { videoId: newCart.itemId },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-        case ItemType.EBOOK:
-          item = await prisma.ebook.findFirst({
-            where: { id: newCart.itemId, isPublic: true },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-        case ItemType.WORKSHOP:
-          item = await prisma.workshop.findUnique({
-            where: { id: newCart.itemId },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              startDate: true
-            }
-          });
-          break;
-        case ItemType.COURSE:
-          item = await prisma.course.findFirst({
-            where: { id: newCart.itemId, isPublic: true },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-      }
-    } catch (err) {
+    if (existing) {
       return NextResponse.json(
-        { error: `Failed to get item details: ${err}` },
-        { status: 500 }
+        { error: 'Item already exists in cart' },
+        { status: 409 }
       );
     }
-    return { ...newCart, ...item };
-  });
 
-  return NextResponse.json(cart);
+    const cart = await prisma.$transaction(async (tx) => {
+      const newCart = await tx.cart.create({
+        data: { userId, itemId, itemType }
+      });
+      let item = null;
+
+      try {
+        switch (newCart.itemType) {
+          case ItemType.VIDEO:
+            item = await prisma.video.findUnique({
+              where: { videoId: newCart.itemId },
+              select: {
+                id: true,
+                title: true,
+                price: true,
+                description: true,
+                category: true
+              }
+            });
+            break;
+          case ItemType.EBOOK:
+            item = await prisma.ebook.findFirst({
+              where: { id: newCart.itemId, isPublic: true },
+              select: {
+                id: true,
+                title: true,
+                price: true,
+                description: true,
+                category: true
+              }
+            });
+            break;
+          case ItemType.WORKSHOP:
+            item = await prisma.workshop.findUnique({
+              where: { id: newCart.itemId },
+              select: {
+                id: true,
+                title: true,
+                price: true,
+                description: true,
+                startDate: true
+              }
+            });
+            break;
+          case ItemType.COURSE:
+            item = await prisma.course.findFirst({
+              where: { id: newCart.itemId, isPublic: true },
+              select: {
+                id: true,
+                title: true,
+                price: true,
+                description: true,
+                category: true
+              }
+            });
+            break;
+        }
+      } catch (err) {
+        throw new Error('Failed to get item details', { cause: err });
+      }
+      return { ...newCart, ...item };
+    });
+
+    return NextResponse.json(cart);
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to add item to cart');
+  }
 }
 
 export async function DELETE(req: NextRequest) {
   try {
-    const { searchParams } = new URL(req.url);
-    const userId = searchParams.get('userId');
+    const userId = await requireCurrentUserId();
 
-    if (!userId) {
-      return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
-    }
-
-    const body = await req.json();
+    const body = await req.json().catch(() => ({}));
 
     const itemIds: string[] = Array.isArray(body.itemIds)
       ? body.itemIds
       : [body.itemIds];
 
-    if (itemIds.length === 0) {
+    if (
+      itemIds.length === 0 ||
+      itemIds.some((itemId) => typeof itemId !== 'string' || !itemId)
+    ) {
       return NextResponse.json(
         { error: 'No items to delete' },
         { status: 400 }
@@ -209,9 +202,6 @@ export async function DELETE(req: NextRequest) {
       deletedIds: itemIds
     });
   } catch (err) {
-    return NextResponse.json(
-      { error: 'Failed to remove item(s) from cart:', err },
-      { status: 500 }
-    );
+    return apiErrorResponse(err, 'Failed to remove items from cart');
   }
 }

--- a/src/app/api/favorites/route.ts
+++ b/src/app/api/favorites/route.ts
@@ -1,29 +1,118 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { ItemType } from '@prisma/client';
+import { requireCurrentUserId } from '@/lib/current-user';
+import { apiErrorResponse, isItemType } from '@/lib/api-request';
 
-export async function GET(req: NextRequest) {
-  const userId = req.nextUrl.searchParams.get('userId');
-  if (!userId)
-    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+export async function GET() {
+  try {
+    const userId = await requireCurrentUserId();
 
-  const favorites = await prisma.favorite.findMany({
-    where: { userId },
-    select: {
-      itemId: true,
-      itemType: true
-    }
-  });
+    const favorites = await prisma.favorite.findMany({
+      where: { userId },
+      select: {
+        itemId: true,
+        itemType: true
+      }
+    });
 
-  const detailedFavorites = await Promise.all(
-    favorites.map(async (favorite) => {
+    const detailedFavorites = await Promise.all(
+      favorites.map(async (favorite) => {
+        let item = null;
+
+        try {
+          switch (favorite.itemType) {
+            case ItemType.VIDEO:
+              item = await prisma.video.findUnique({
+                where: { videoId: favorite.itemId },
+                select: {
+                  id: true,
+                  title: true,
+                  price: true,
+                  description: true,
+                  category: true
+                }
+              });
+              break;
+            case ItemType.EBOOK:
+              item = await prisma.ebook.findFirst({
+                where: {
+                  isPublic: true,
+                  OR: [{ ebookId: favorite.itemId }, { id: favorite.itemId }]
+                },
+                select: {
+                  id: true,
+                  title: true,
+                  price: true,
+                  description: true,
+                  category: true
+                }
+              });
+              break;
+            case ItemType.WORKSHOP:
+              item = await prisma.workshop.findUnique({
+                where: { id: favorite.itemId },
+                select: {
+                  id: true,
+                  title: true,
+                  price: true,
+                  description: true,
+                  startDate: true
+                }
+              });
+              break;
+            case ItemType.COURSE:
+              item = await prisma.course.findFirst({
+                where: { id: favorite.itemId, isPublic: true },
+                select: {
+                  id: true,
+                  title: true,
+                  price: true,
+                  description: true,
+                  category: true
+                }
+              });
+              break;
+          }
+        } catch (error) {
+          throw new Error('Item lookup failed', { cause: error });
+        }
+        return { ...favorite, ...item };
+      })
+    );
+    return NextResponse.json(detailedFavorites);
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to fetch favorites');
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const userId = await requireCurrentUserId();
+    const { itemId, itemType } = await req.json().catch(() => ({}));
+
+    if (typeof itemId !== 'string' || !itemId.trim() || !isItemType(itemType))
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+
+    const favorite = await prisma.$transaction(async (tx) => {
+      const newFavorite = await tx.favorite.upsert({
+        where: {
+          userId_itemType_itemId: {
+            userId,
+            itemType,
+            itemId
+          }
+        },
+        update: {},
+        create: { userId, itemId, itemType }
+      });
       let item = null;
 
       try {
-        switch (favorite.itemType) {
+        switch (newFavorite.itemType) {
           case ItemType.VIDEO:
-            item = await prisma.video.findUnique({
-              where: { videoId: favorite.itemId },
+            item = await tx.video.findUnique({
+              where: { videoId: newFavorite.itemId },
               select: {
                 id: true,
                 title: true,
@@ -34,10 +123,13 @@ export async function GET(req: NextRequest) {
             });
             break;
           case ItemType.EBOOK:
-            item = await prisma.ebook.findFirst({
+            item = await tx.ebook.findFirst({
               where: {
                 isPublic: true,
-                OR: [{ ebookId: favorite.itemId }, { id: favorite.itemId }]
+                OR: [
+                  { ebookId: newFavorite.itemId },
+                  { id: newFavorite.itemId }
+                ]
               },
               select: {
                 id: true,
@@ -49,8 +141,8 @@ export async function GET(req: NextRequest) {
             });
             break;
           case ItemType.WORKSHOP:
-            item = await prisma.workshop.findUnique({
-              where: { id: favorite.itemId },
+            item = await tx.workshop.findUnique({
+              where: { id: newFavorite.itemId },
               select: {
                 id: true,
                 title: true,
@@ -61,8 +153,8 @@ export async function GET(req: NextRequest) {
             });
             break;
           case ItemType.COURSE:
-            item = await prisma.course.findFirst({
-              where: { id: favorite.itemId, isPublic: true },
+            item = await tx.course.findFirst({
+              where: { id: newFavorite.itemId, isPublic: true },
               select: {
                 id: true,
                 title: true,
@@ -73,121 +165,38 @@ export async function GET(req: NextRequest) {
             });
             break;
         }
-      } catch (error) {
-        return NextResponse.json(
-          { error: `Item lookup failed: ${error}` },
-          { status: 500 }
-        );
+      } catch (err) {
+        throw new Error('Failed to get item details', { cause: err });
       }
-      return { ...favorite, ...item };
-    })
-  );
-  return NextResponse.json(detailedFavorites);
-}
-
-export async function POST(req: NextRequest) {
-  const body = await req.json();
-  const { userId, itemId, itemType } = body;
-
-  if (!userId || !itemId || !itemType)
-    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
-
-  const favorite = await prisma.$transaction(async (tx) => {
-    const newFavorite = await tx.favorite.upsert({
-      where: {
-        userId_itemType_itemId: {
-          userId,
-          itemType,
-          itemId
-        }
-      },
-      update: {},
-      create: { userId, itemId, itemType }
+      return { ...newFavorite, ...item };
     });
-    let item = null;
 
-    try {
-      switch (newFavorite.itemType) {
-        case ItemType.VIDEO:
-          item = await tx.video.findUnique({
-            where: { videoId: newFavorite.itemId },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-        case ItemType.EBOOK:
-          item = await tx.ebook.findFirst({
-            where: {
-              isPublic: true,
-              OR: [{ ebookId: newFavorite.itemId }, { id: newFavorite.itemId }]
-            },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-        case ItemType.WORKSHOP:
-          item = await tx.workshop.findUnique({
-            where: { id: newFavorite.itemId },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              startDate: true
-            }
-          });
-          break;
-        case ItemType.COURSE:
-          item = await tx.course.findFirst({
-            where: { id: newFavorite.itemId, isPublic: true },
-            select: {
-              id: true,
-              title: true,
-              price: true,
-              description: true,
-              category: true
-            }
-          });
-          break;
-      }
-    } catch (err) {
-      return NextResponse.json(
-        { error: `Failed to get item details: ${err}` },
-        { status: 500 }
-      );
-    }
-    return { ...newFavorite, ...item };
-  });
-
-  return NextResponse.json(favorite);
+    return NextResponse.json(favorite);
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to add favorite');
+  }
 }
 
 export async function DELETE(req: NextRequest) {
-  const { searchParams } = req.nextUrl;
-  const userId = searchParams.get('userId');
-  const itemId = searchParams.get('itemId');
-  const itemType = searchParams.get('itemType') as ItemType | null;
+  try {
+    const userId = await requireCurrentUserId();
+    const { searchParams } = req.nextUrl;
+    const itemId = searchParams.get('itemId');
+    const itemType = searchParams.get('itemType') as ItemType | null;
 
-  if (!userId || !itemId || !itemType)
-    return NextResponse.json({ error: 'Missing params' }, { status: 400 });
+    if (!itemId || !isItemType(itemType))
+      return NextResponse.json({ error: 'Missing params' }, { status: 400 });
 
-  await prisma.favorite.deleteMany({
-    where: {
-      userId,
-      itemId,
-      itemType
-    }
-  });
+    await prisma.favorite.deleteMany({
+      where: {
+        userId,
+        itemId,
+        itemType
+      }
+    });
 
-  return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return apiErrorResponse(err, 'Failed to remove favorite');
+  }
 }

--- a/src/app/api/interest/route.ts
+++ b/src/app/api/interest/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { requireCurrentUserId } from '@/lib/current-user';
+import { apiErrorResponse, hasValidInterests } from '@/lib/api-request';
 
-export async function GET(req: NextRequest) {
+export async function GET() {
   try {
-    const userId = req.nextUrl.searchParams.get('userId');
-    if (!userId)
-      return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+    const userId = await requireCurrentUserId();
 
     const userWithInterests = await prisma.user.findUnique({
       where: { id: userId },
@@ -16,20 +16,18 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(userWithInterests);
   } catch (err) {
-    return NextResponse.json(
-      { error: `GET /api/cart error: ${err}` },
-      { status: 500 }
-    );
+    return apiErrorResponse(err, 'Failed to fetch interests');
   }
 }
 
 export async function PUT(req: NextRequest) {
   try {
-    const { userId, interests } = await req.json();
+    const userId = await requireCurrentUserId();
+    const { interests } = await req.json().catch(() => ({}));
 
-    if (!userId || !Array.isArray(interests)) {
+    if (!hasValidInterests(interests)) {
       return NextResponse.json(
-        { error: 'Invalid request: userId and interests are required.' },
+        { error: 'Invalid request: interests are required.' },
         { status: 400 }
       );
     }
@@ -45,9 +43,6 @@ export async function PUT(req: NextRequest) {
       { status: 200 }
     );
   } catch (err) {
-    return NextResponse.json(
-      { error: `Failed to update interests: ${err}` },
-      { status: 500 }
-    );
+    return apiErrorResponse(err, 'Failed to update interests');
   }
 }

--- a/src/app/api/ownership.test.ts
+++ b/src/app/api/ownership.test.ts
@@ -1,0 +1,415 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import type { Mock } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn()
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  user: {
+    findUnique: vi.fn(),
+    update: vi.fn()
+  },
+  cart: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    deleteMany: vi.fn()
+  },
+  favorite: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn()
+  },
+  $transaction: vi.fn(),
+  video: {
+    findUnique: vi.fn()
+  }
+}));
+
+const transaction = {
+  cart: {
+    create: vi.fn()
+  },
+  favorite: {
+    upsert: vi.fn()
+  },
+  video: {
+    findUnique: vi.fn()
+  }
+};
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+const { auth } = await import('@clerk/nextjs/server');
+const {
+  GET: cartGet,
+  POST: cartPost,
+  DELETE: cartDelete
+} = await import('./cart/route');
+const {
+  GET: favoritesGet,
+  POST: favoritesPost,
+  DELETE: favoritesDelete
+} = await import('./favorites/route');
+const { GET: interestGet, PUT: interestPut } = await import('./interest/route');
+
+type GetHandler = (request: NextRequest) => Promise<Response>;
+
+const getCart = cartGet as GetHandler;
+const getFavorites = favoritesGet as GetHandler;
+const getInterest = interestGet as GetHandler;
+const postCart = cartPost as GetHandler;
+const deleteCart = cartDelete as GetHandler;
+const postFavorite = favoritesPost as GetHandler;
+const deleteFavorite = favoritesDelete as GetHandler;
+const putInterest = interestPut as GetHandler;
+
+const clerkUserId = 'clerk-user-1';
+const applicationUserId = '11111111-1111-4111-8111-111111111111';
+const anotherUserId = '22222222-2222-4222-8222-222222222222';
+
+function request(path: string) {
+  return new NextRequest(`http://localhost${path}`);
+}
+
+function jsonRequest(path: string, method: string, body: unknown) {
+  return new NextRequest(`http://localhost${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+}
+
+function malformedJsonRequest(path: string, method: string) {
+  return new NextRequest(`http://localhost${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: '{'
+  });
+}
+
+describe('personal-data API ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as unknown as Mock).mockResolvedValue({ userId: clerkUserId });
+    prismaMock.user.findUnique.mockResolvedValue({ id: applicationUserId });
+    prismaMock.cart.findMany.mockResolvedValue([]);
+    prismaMock.favorite.findMany.mockResolvedValue([]);
+    prismaMock.cart.findFirst.mockResolvedValue(null);
+    prismaMock.cart.deleteMany.mockResolvedValue({ count: 1 });
+    prismaMock.favorite.deleteMany.mockResolvedValue({ count: 1 });
+    prismaMock.video.findUnique.mockResolvedValue({
+      id: 'video-db-id',
+      title: 'Video',
+      price: '1',
+      description: 'Description',
+      category: null
+    });
+    transaction.cart.create.mockResolvedValue({
+      itemId: 'video-id',
+      itemType: 'VIDEO'
+    });
+    transaction.favorite.upsert.mockResolvedValue({
+      itemId: 'video-id',
+      itemType: 'VIDEO'
+    });
+    transaction.video.findUnique.mockResolvedValue({
+      id: 'video-db-id',
+      title: 'Video',
+      price: '1',
+      description: 'Description',
+      category: null
+    });
+    prismaMock.$transaction.mockImplementation(async (callback) =>
+      callback(transaction)
+    );
+  });
+
+  it.each([
+    ['cart', getCart, '/api/cart?userId=' + anotherUserId],
+    ['favorites', getFavorites, '/api/favorites?userId=' + anotherUserId]
+  ])(
+    'uses the authenticated application user for %s, not client userId',
+    async (_name, handler, path) => {
+      const response = await handler(request(path));
+
+      expect(response.status).toBe(200);
+      expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+        where: { clerkId: clerkUserId },
+        select: { id: true }
+      });
+    }
+  );
+
+  it('uses the authenticated application user for cart data', async () => {
+    await getCart(request(`/api/cart?userId=${anotherUserId}`));
+
+    expect(prismaMock.cart.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: applicationUserId } })
+    );
+  });
+
+  it('uses the authenticated application user for favorite data', async () => {
+    await getFavorites(request(`/api/favorites?userId=${anotherUserId}`));
+
+    expect(prismaMock.favorite.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: applicationUserId } })
+    );
+  });
+
+  it('uses the authenticated application user for interests', async () => {
+    prismaMock.user.findUnique
+      .mockResolvedValueOnce({ id: applicationUserId })
+      .mockResolvedValueOnce({ interest: ['IT'] });
+
+    const response = await getInterest(
+      request(`/api/interest?userId=${anotherUserId}`)
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.user.findUnique).toHaveBeenLastCalledWith({
+      where: { id: applicationUserId },
+      select: { interest: true }
+    });
+  });
+
+  it('uses the authenticated application user when adding a cart item', async () => {
+    const response = await postCart(
+      jsonRequest('/api/cart', 'POST', {
+        userId: anotherUserId,
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.cart.findFirst).toHaveBeenCalledWith({
+      where: {
+        userId: applicationUserId,
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      }
+    });
+    expect(transaction.cart.create).toHaveBeenCalledWith({
+      data: {
+        userId: applicationUserId,
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      }
+    });
+  });
+
+  it('uses the authenticated application user when deleting cart items', async () => {
+    const response = await deleteCart(
+      jsonRequest(`/api/cart?userId=${anotherUserId}`, 'DELETE', {
+        itemIds: ['video-id']
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.cart.deleteMany).toHaveBeenCalledWith({
+      where: { userId: applicationUserId, itemId: { in: ['video-id'] } }
+    });
+  });
+
+  it('does not create a duplicate cart item', async () => {
+    prismaMock.cart.findFirst.mockResolvedValue({ id: 'existing-cart-item' });
+
+    const response = await postCart(
+      jsonRequest('/api/cart', 'POST', {
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      })
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Item already exists in cart'
+    });
+    expect(transaction.cart.create).not.toHaveBeenCalled();
+  });
+
+  it('uses the authenticated application user when adding a favorite', async () => {
+    const response = await postFavorite(
+      jsonRequest('/api/favorites', 'POST', {
+        userId: anotherUserId,
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(transaction.favorite.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: {
+          userId: applicationUserId,
+          itemId: 'video-id',
+          itemType: 'VIDEO'
+        }
+      })
+    );
+  });
+
+  it('uses the authenticated application user when deleting a favorite', async () => {
+    const response = await deleteFavorite(
+      request(
+        `/api/favorites?userId=${anotherUserId}&itemId=video-id&itemType=VIDEO`
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.favorite.deleteMany).toHaveBeenCalledWith({
+      where: {
+        userId: applicationUserId,
+        itemId: 'video-id',
+        itemType: 'VIDEO'
+      }
+    });
+  });
+
+  it('uses the authenticated application user when updating interests', async () => {
+    prismaMock.user.findUnique.mockResolvedValueOnce({ id: applicationUserId });
+    prismaMock.user.update.mockResolvedValue({
+      id: applicationUserId,
+      interest: ['IT']
+    });
+
+    const response = await putInterest(
+      jsonRequest('/api/interest', 'PUT', {
+        userId: anotherUserId,
+        interests: ['IT']
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: applicationUserId },
+      data: { interest: ['IT'] },
+      select: { id: true, interest: true }
+    });
+  });
+
+  it.each([
+    ['cart POST', postCart, jsonRequest('/api/cart', 'POST', {})],
+    ['cart DELETE', deleteCart, jsonRequest('/api/cart', 'DELETE', {})],
+    ['favorites POST', postFavorite, jsonRequest('/api/favorites', 'POST', {})],
+    ['favorites DELETE', deleteFavorite, request('/api/favorites')],
+    ['interest PUT', putInterest, jsonRequest('/api/interest', 'PUT', {})]
+  ])('returns 400 for invalid %s input', async (_name, handler, req) => {
+    const response = await handler(req);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toHaveProperty('error');
+  });
+
+  it.each([
+    ['cart POST', postCart, jsonRequest('/api/cart', 'POST', {})],
+    ['cart DELETE', deleteCart, jsonRequest('/api/cart', 'DELETE', {})],
+    ['favorites POST', postFavorite, jsonRequest('/api/favorites', 'POST', {})],
+    ['favorites DELETE', deleteFavorite, request('/api/favorites')],
+    ['interest PUT', putInterest, jsonRequest('/api/interest', 'PUT', {})]
+  ])(
+    'returns 401 before parsing an unauthenticated %s request',
+    async (_name, handler, req) => {
+      (auth as unknown as Mock).mockResolvedValue({ userId: null });
+
+      const response = await handler(req);
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    }
+  );
+
+  it.each([
+    ['cart', getCart, '/api/cart'],
+    ['favorites', getFavorites, '/api/favorites'],
+    ['interest', getInterest, '/api/interest']
+  ])(
+    'returns 401 for an unauthenticated %s request',
+    async (_name, handler, path) => {
+      (auth as unknown as Mock).mockResolvedValue({ userId: null });
+
+      const response = await handler(request(path));
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    }
+  );
+
+  it.each([
+    ['cart', getCart, request('/api/cart')],
+    ['favorites', getFavorites, request('/api/favorites')],
+    ['interest', getInterest, request('/api/interest')],
+    ['cart POST', postCart, jsonRequest('/api/cart', 'POST', {})],
+    ['cart DELETE', deleteCart, jsonRequest('/api/cart', 'DELETE', {})],
+    ['favorites POST', postFavorite, jsonRequest('/api/favorites', 'POST', {})],
+    ['favorites DELETE', deleteFavorite, request('/api/favorites')],
+    ['interest PUT', putInterest, jsonRequest('/api/interest', 'PUT', {})]
+  ])(
+    'returns 404 when the authenticated %s user has no application record',
+    async (_name, handler, req) => {
+      prismaMock.user.findUnique.mockResolvedValue(null);
+
+      const response = await handler(req);
+
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toEqual({
+        error: 'User not found'
+      });
+    }
+  );
+
+  it.each([
+    [
+      'cart POST',
+      postCart,
+      jsonRequest('/api/cart', 'POST', {
+        itemId: 'video-id',
+        itemType: 'INVALID'
+      })
+    ],
+    [
+      'favorites DELETE',
+      deleteFavorite,
+      request('/api/favorites?itemId=video-id&itemType=INVALID')
+    ],
+    [
+      'interest PUT',
+      putInterest,
+      jsonRequest('/api/interest', 'PUT', { interests: ['INVALID'] })
+    ]
+  ])('returns 400 for an invalid enum in %s', async (_name, handler, req) => {
+    const response = await handler(req);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toHaveProperty('error');
+  });
+
+  it.each([
+    ['cart POST', postCart, malformedJsonRequest('/api/cart', 'POST')],
+    [
+      'favorites POST',
+      postFavorite,
+      malformedJsonRequest('/api/favorites', 'POST')
+    ],
+    ['interest PUT', putInterest, malformedJsonRequest('/api/interest', 'PUT')]
+  ])('returns 400 for malformed JSON in %s', async (_name, handler, req) => {
+    const response = await handler(req);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toHaveProperty('error');
+  });
+
+  it('returns a generic 500 response when a cart query fails', async () => {
+    prismaMock.cart.findMany.mockRejectedValue(new Error('database details'));
+
+    const response = await getCart(request('/api/cart'));
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to fetch cart'
+    });
+  });
+});

--- a/src/app/context/cart-context.tsx
+++ b/src/app/context/cart-context.tsx
@@ -38,13 +38,17 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
 
   const fetchCart = useCallback(async () => {
     try {
-      const res = await fetch(`/api/cart?userId=${userId}`);
+      const res = await fetch('/api/cart');
+      if (!res.ok) {
+        throw new Error(`Failed with status ${res.status}`);
+      }
+
       const data = await res.json();
       setCart(data);
     } catch (err) {
       toast.error(`Failed to fetch cart: ${err}`);
     }
-  }, [userId]);
+  }, []);
 
   useEffect(() => {
     if (!userId) {
@@ -60,7 +64,7 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
       const res = await fetch('/api/cart', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, itemId, itemType })
+        body: JSON.stringify({ itemId, itemType })
       });
 
       if (res.status === 409) {
@@ -87,7 +91,7 @@ export const CartProvider = ({ children }: { children: React.ReactNode }) => {
     try {
       const ids = Array.isArray(itemIds) ? itemIds : [itemIds];
 
-      const res = await fetch(`/api/cart?userId=${userId}`, {
+      const res = await fetch('/api/cart', {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ itemIds: ids })

--- a/src/app/context/favorite-context.tsx
+++ b/src/app/context/favorite-context.tsx
@@ -44,7 +44,11 @@ export const FavoriteProvider = ({
 
     const fetchFavorites = async () => {
       try {
-        const res = await fetch(`/api/favorites?userId=${userId}`);
+        const res = await fetch('/api/favorites');
+        if (!res.ok) {
+          throw new Error(`Failed with status ${res.status}`);
+        }
+
         const data = await res.json();
         setFavorites(data);
       } catch (err) {
@@ -68,7 +72,7 @@ export const FavoriteProvider = ({
       const res = await fetch('/api/favorites', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, itemId, itemType })
+        body: JSON.stringify({ itemId, itemType })
       });
 
       if (res.status === 409) {
@@ -96,12 +100,17 @@ export const FavoriteProvider = ({
 
   const removeFavorite = async (itemId: string, itemType: ItemType) => {
     try {
-      await fetch(
-        `/api/favorites?userId=${userId}&itemId=${itemId}&itemType=${itemType}`,
+      const res = await fetch(
+        `/api/favorites?itemId=${itemId}&itemType=${itemType}`,
         {
           method: 'DELETE'
         }
       );
+
+      if (!res.ok) {
+        throw new Error(`Failed with status ${res.status}`);
+      }
+
       setFavorites((prev) =>
         prev.filter((f) => !(f.itemId === itemId && f.itemType === itemType))
       );

--- a/src/app/mypage/setting/page.tsx
+++ b/src/app/mypage/setting/page.tsx
@@ -24,7 +24,8 @@ export default function SettingsPage() {
   useEffect(() => {
     if (!user && !isLoading) {
       toast('Please sign in');
-      return router.push('/');
+      router.push('/');
+      return;
     }
 
     if (user && user.nickname) {
@@ -32,9 +33,19 @@ export default function SettingsPage() {
     }
 
     const fetchInterests = async () => {
-      const res = await fetch(`/api/interest?userId=${user?.id}`);
-      const data = await res.json();
-      setSelectedInterests(data.interest);
+      if (!user) return;
+
+      try {
+        const res = await fetch('/api/interest');
+        if (!res.ok) {
+          throw new Error(`Failed with status ${res.status}`);
+        }
+
+        const data = await res.json();
+        setSelectedInterests(data.interest);
+      } catch (err) {
+        toast.error(`Failed to fetch interests: ${err}`);
+      }
     };
     fetchInterests();
   }, [user, isLoading, router]);
@@ -94,7 +105,7 @@ export default function SettingsPage() {
       const res = await fetch('/api/interest', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: user.id, interests: selectedInterests })
+        body: JSON.stringify({ interests: selectedInterests })
       });
 
       if (!res.ok) throw new Error('Failed to update');

--- a/src/lib/api-request.ts
+++ b/src/lib/api-request.ts
@@ -1,0 +1,32 @@
+import { Interest, ItemType } from '@prisma/client';
+import { NextResponse } from 'next/server';
+import { CurrentUserError } from '@/lib/current-user';
+
+export function isItemType(value: unknown): value is ItemType {
+  return (
+    typeof value === 'string' &&
+    Object.values(ItemType).includes(value as ItemType)
+  );
+}
+
+export function hasValidInterests(interests: unknown): interests is Interest[] {
+  return (
+    Array.isArray(interests) &&
+    interests.every(
+      (interest) =>
+        typeof interest === 'string' &&
+        Object.values(Interest).includes(interest as Interest)
+    )
+  );
+}
+
+export function apiErrorResponse(error: unknown, fallbackMessage: string) {
+  if (error instanceof CurrentUserError) {
+    return NextResponse.json(
+      { error: error.message },
+      { status: error.status }
+    );
+  }
+
+  return NextResponse.json({ error: fallbackMessage }, { status: 500 });
+}

--- a/src/lib/current-user.ts
+++ b/src/lib/current-user.ts
@@ -1,0 +1,34 @@
+import { auth } from '@clerk/nextjs/server';
+import prisma from '@/lib/prisma';
+
+export class CurrentUserError extends Error {
+  constructor(
+    message: string,
+    public readonly status: 401 | 404
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Resolves the authenticated Clerk user to the application's internal user ID.
+ * API handlers must use this value rather than a user ID supplied by a client.
+ */
+export async function requireCurrentUserId() {
+  const { userId: clerkUserId } = await auth();
+
+  if (!clerkUserId) {
+    throw new CurrentUserError('Unauthorized', 401);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { clerkId: clerkUserId },
+    select: { id: true }
+  });
+
+  if (!user) {
+    throw new CurrentUserError('User not found', 404);
+  }
+
+  return user.id;
+}


### PR DESCRIPTION
## Why this PR:

Cart, favorites, and interest endpoints previously trusted a client-provided `userId`. A signed-in user could replace that value and read or modify another user record.

## Changes:

- Resolve the Clerk-authenticated user to the internal application user ID on the server.
- Ignore client-provided `userId` values for all Cart, Favorites, and Interest API operations.
- Return consistent `401`, `404`, `400`, and generic `500` error responses.
- Validate item types, interests, empty values, and malformed JSON before database writes.
- Remove `userId` from client API requests and prevent failed responses from updating client state.
- Add ownership regression coverage for GET, POST, PUT, and DELETE flows.

## How to Test:

### Automated

1. Run `npm test -- --run src/app/api/ownership.test.ts`.
2. Run `npm test -- --run`, `npm run typecheck`, `npm run build`, and `npm run lint`.

### Manual

1. Start the app with `npm run dev` and sign in as test user A. Ensure a corresponding application user record exists.
2. In a separate browser profile, sign in as test user B and record the internal database user ID for both users from `/api/user`.
3. Sign back in as user A. In DevTools, compare each normal GET response with a request that includes user B ID:
   - `/api/cart` and `/api/cart?userId=<B_USER_ID>`
   - `/api/favorites` and `/api/favorites?userId=<B_USER_ID>`
   - `/api/interest` and `/api/interest?userId=<B_USER_ID>`
   Each pair must return user A data.
4. While signed in as user A, send Cart/Favorites POST and DELETE requests and an Interest PUT request with `userId: <B_USER_ID>` included in the request. Confirm that only user A data changes.
5. Sign in as user B and confirm none of the user A test changes appear.
6. Remove any test cart/favorite entries and restore the original interests before finishing.
7. Sign out and request each API. Each endpoint must return `401 Unauthorized`.
