### PR TITLE
PACE-286 Prevent My Page redirect after first sign-up

### DIFF
--- a/src/app/api/user/route.test.ts
+++ b/src/app/api/user/route.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: vi.fn(),
+  currentUser: vi.fn()
+}));
+
+const prismaMock = {
+  user: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn()
+  }
+};
+
+vi.mock('@/lib/prisma', () => ({
+  default: prismaMock
+}));
+
+const { auth, currentUser } = await import('@clerk/nextjs/server');
+const { GET } = await import('./route');
+
+describe('GET /api/user', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ userId: null } as never);
+    vi.mocked(currentUser).mockResolvedValue(null as never);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'Unauthorized' });
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns the existing application user', async () => {
+    const existingUser = { id: 'user-id', clerkId: 'clerk-user-id' };
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk-user-id' } as never);
+    prismaMock.user.findUnique.mockResolvedValue(existingUser);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(existingUser);
+    expect(currentUser).not.toHaveBeenCalled();
+    expect(prismaMock.user.upsert).not.toHaveBeenCalled();
+  });
+
+  it('provisions an application user when the Clerk webhook has not arrived yet', async () => {
+    const provisionedUser = {
+      id: 'user-id',
+      clerkId: 'clerk-user-id',
+      email: 'new-user@example.com',
+      name: 'New User'
+    };
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk-user-id' } as never);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    vi.mocked(currentUser).mockResolvedValue({
+      firstName: 'New',
+      lastName: 'User',
+      primaryEmailAddress: { emailAddress: 'new-user@example.com' },
+      emailAddresses: [{ emailAddress: 'new-user@example.com' }],
+      unsafeMetadata: {}
+    } as never);
+    prismaMock.user.upsert.mockResolvedValue(provisionedUser);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(provisionedUser);
+    expect(prismaMock.user.upsert).toHaveBeenCalledWith({
+      where: { clerkId: 'clerk-user-id' },
+      create: expect.objectContaining({
+        clerkId: 'clerk-user-id',
+        email: 'new-user@example.com',
+        name: 'New User'
+      }),
+      update: {}
+    });
+  });
+
+  it('uses custom email sign-up metadata when Clerk profile names are unavailable', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk-user-id' } as never);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    vi.mocked(currentUser).mockResolvedValue({
+      firstName: null,
+      lastName: null,
+      primaryEmailAddress: { emailAddress: 'new-user@example.com' },
+      emailAddresses: [{ emailAddress: 'new-user@example.com' }],
+      unsafeMetadata: { firstName: 'Email', lastName: 'User' }
+    } as never);
+    prismaMock.user.upsert.mockResolvedValue({ id: 'user-id' });
+
+    await GET();
+
+    expect(prismaMock.user.upsert).toHaveBeenCalledWith({
+      where: { clerkId: 'clerk-user-id' },
+      create: expect.objectContaining({ name: 'Email User' }),
+      update: {}
+    });
+  });
+
+  it('does not create a database user when Clerk user details are unavailable', async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: 'clerk-user-id' } as never);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({
+      error: 'Unable to provision the authenticated user.'
+    });
+    expect(prismaMock.user.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,6 +1,20 @@
 import prisma from '@/lib/prisma';
 import { NextResponse } from 'next/server';
-import { auth } from '@clerk/nextjs/server';
+import { auth, currentUser } from '@clerk/nextjs/server';
+import { v4 as uuidv4 } from 'uuid';
+
+function getClerkUserName(clerkUser: Awaited<ReturnType<typeof currentUser>>) {
+  if (!clerkUser) return null;
+
+  const metadata = clerkUser.unsafeMetadata as {
+    firstName?: unknown;
+    lastName?: unknown;
+  };
+  const firstName = clerkUser.firstName || metadata.firstName || '';
+  const lastName = clerkUser.lastName || metadata.lastName || '';
+
+  return `${firstName} ${lastName}`.trim() || null;
+}
 
 export async function GET() {
   try {
@@ -10,12 +24,43 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const users = await prisma.user.findUnique({
+    const existingUser = await prisma.user.findUnique({
       where: {
         clerkId: userId
       }
     });
-    return NextResponse.json(users, { status: 200 });
+
+    if (existingUser) {
+      return NextResponse.json(existingUser, { status: 200 });
+    }
+
+    // Clerk creates the session before its user.created webhook is guaranteed to
+    // reach this app. Provision here as well so a newly signed-up user is never
+    // treated as signed out while that webhook is still in flight.
+    const clerkUser = await currentUser();
+    const email =
+      clerkUser?.primaryEmailAddress?.emailAddress ??
+      clerkUser?.emailAddresses[0]?.emailAddress;
+
+    if (!clerkUser || !email) {
+      return NextResponse.json(
+        { error: 'Unable to provision the authenticated user.' },
+        { status: 409 }
+      );
+    }
+
+    const user = await prisma.user.upsert({
+      where: { clerkId: userId },
+      create: {
+        id: uuidv4(),
+        clerkId: userId,
+        email,
+        name: getClerkUserName(clerkUser)
+      },
+      update: {}
+    });
+
+    return NextResponse.json(user, { status: 200 });
   } catch (error) {
     return NextResponse.json(
       { error: `Failed to fetch users: ${error}` },


### PR DESCRIPTION
## Why this PR:

Newly signed-up users could have an active Clerk session before the `user.created` webhook created their application user record. In that short window, `/api/user` returned `null`, and navigating to My Page redirected the user home with a “Please sign in” toast.

## Changes:

- Return existing application users from `/api/user` as before.
- When an authenticated Clerk user has no application user record yet, create it with an atomic `upsert`.
- Use Clerk profile details and custom email sign-up metadata to populate the new user record.
- Keep the webhook as the normal synchronization path; the API fallback only closes the first-sign-up timing gap.
- Add coverage for unauthenticated access, existing users, delayed webhook provisioning, custom email metadata, and unavailable Clerk user details.

## How to Test:

### Automated

1. Run `npm test -- --run src/app/api/user/route.test.ts`.
2. Run `npm test -- --run`.
3. Run `npm run typecheck`, `npm run build`, and `npm run lint`.

### Manual

1. Start the app with `npm run dev` and open the sign-up page in a signed-out browser session.
2. Complete a new email sign-up and email verification.
3. As soon as the app returns to the home page, open the profile menu and click **My Page**.
4. Confirm the page stays on `/mypage`, shows the signed-in user, and does not display the `Please sign in` toast.
5. Repeat the flow with **Continue with Google**. After the OAuth callback returns to the app, open the profile menu and click **My Page**. Confirm the same result.
6. Sign out after testing and remove any test application user records created in the local database.