### PR TITLE
PACE-270 Suppress invalid video ID toast on non-video routes

### DIFF
--- a/public/html/courses/course_detail.html
+++ b/public/html/courses/course_detail.html
@@ -445,7 +445,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -2031,6 +2032,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/courses/course_detail_video.html
+++ b/public/html/courses/course_detail_video.html
@@ -444,7 +444,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -2502,6 +2503,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/courses/course_list.html
+++ b/public/html/courses/course_list.html
@@ -819,7 +819,8 @@
         }
 
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;

--- a/public/html/ebooks/ebook_detail.html
+++ b/public/html/ebooks/ebook_detail.html
@@ -301,7 +301,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -1543,6 +1544,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/ebooks/ebook_list.html
+++ b/public/html/ebooks/ebook_list.html
@@ -842,7 +842,8 @@
         }
 
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
 
           opacity: 1;
 
@@ -2122,6 +2123,18 @@
             var panel = document.getElementById(targetId);
             if (!panel) return;
             var isExpanded = btn.getAttribute('aria-expanded') === 'true';
+            if (!isExpanded) {
+              accordions.forEach(function (otherBtn) {
+                if (otherBtn !== btn) {
+                  otherBtn.setAttribute('aria-expanded', 'false');
+                  var otherTargetId = otherBtn.getAttribute('data-target');
+                  var otherPanel = otherTargetId ? document.getElementById(otherTargetId) : null;
+                  if (otherPanel) {
+                    otherPanel.classList.remove('is-open');
+                  }
+                }
+              });
+            }
             btn.setAttribute('aria-expanded', isExpanded ? 'false' : 'true');
             panel.classList.toggle('is-open', !isExpanded);
           });

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -596,13 +596,17 @@
           <td>장바구니</td>
           <td>담긴 상품·선택·결제 버튼</td>
           <td></td>
-          <td></td>
+          <td>
+            <a href="./mypage/cart.html" rel="noopener noreferrer" target="_blank"
+              >cart.html</a
+            >
+          </td>
           <td>
             <select aria-label="진행" class="pm-progress">
-              <option selected="selected" value="">—</option>
+              <option value="">—</option>
               <option value="wait">대기</option>
               <option value="wip">진행</option>
-              <option value="done">완료</option>
+              <option value="done" selected="selected">완료</option>
             </select>
           </td>
           <td>레이아웃 변형 있음</td>
@@ -612,13 +616,17 @@
           <td>장바구니 하단 바</td>
           <td>합계·주문하기 고정 하단 UI</td>
           <td></td>
-          <td></td>
+          <td>
+            <a href="./mypage/cart.html" rel="noopener noreferrer" target="_blank"
+              >cart.html</a
+            >
+          </td>
           <td>
             <select aria-label="진행" class="pm-progress">
-              <option selected="selected" value="">—</option>
+              <option value="">—</option>
               <option value="wait">대기</option>
               <option value="wip">진행</option>
-              <option value="done">완료</option>
+              <option value="done" selected="selected">완료</option>
             </select>
           </td>
           <td>컴포넌트</td>

--- a/public/html/index.html
+++ b/public/html/index.html
@@ -580,13 +580,20 @@
           <td>찜 목록</td>
           <td>찜한 강의/콘텐츠 카드 그리드</td>
           <td></td>
-          <td></td>
+          <td>
+            <a
+              href="./mypage/wishlist.html"
+              rel="noopener noreferrer"
+              target="_blank"
+              >wishlist.html</a
+            >
+          </td>
           <td>
             <select aria-label="진행" class="pm-progress">
-              <option selected="selected" value="">—</option>
+              <option value="">—</option>
               <option value="wait">대기</option>
               <option value="wip">진행</option>
-              <option value="done">완료</option>
+              <option value="done" selected="selected">완료</option>
             </select>
           </td>
           <td>피그마 라벨: 찜목록</td>

--- a/public/html/main.html
+++ b/public/html/main.html
@@ -522,7 +522,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -4262,6 +4263,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -617,7 +617,7 @@
                       href="cart.html"
                     >
                       <div
-                        class="mt-0.5 p-2 rounded-lg bg-orange/5 text-orange transition-colors shadow-sm border border-transparent"
+                        class="mt-0.5 p-2 rounded-lg bg-orange/5 text-orange transition-colors shadow-sm border border-transparent relative"
                       >
                         <span class="material-symbols-outlined text-[20px]"
                           >shopping_cart</span

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -1,0 +1,1721 @@
+<!doctype html>
+<html
+  class="light"
+  lang="en"
+  style="--font-heading: 'Poppins', ui-sans-serif, system-ui, sans-serif"
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pacemaker | Cart</title>
+
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700;800&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              navy: '#00263b',
+              teal: '#00adbd',
+              orange: '#ff4f02',
+              'orange-hover': '#e04400',
+              'gray-soft': '#f2f4f7',
+              'surface-container-low': '#f2f4f7',
+              surface: '#f7f9fc',
+              body: '#475467'
+            },
+            fontFamily: {
+              headline: ['Poppins', 'sans-serif'],
+              body: ['Source Sans 3', 'sans-serif'],
+              label: ['Poppins', 'sans-serif']
+            },
+            boxShadow: {
+              card: '0 10px 30px rgba(0,38,59,0.08)'
+            },
+            borderRadius: {
+              DEFAULT: '0.125rem',
+              lg: '0.25rem',
+              xl: '0.5rem',
+              '2xl': '16px',
+              full: '9999px'
+            }
+          }
+        }
+      };
+    </script>
+
+    <style>
+      html {
+        scrollbar-gutter: stable;
+      }
+
+      body {
+        max-width: 1920px;
+        margin: 0 auto;
+        background-color: #f7f9fc;
+        font-family: 'Source Sans 3', sans-serif;
+        color: #475467;
+      }
+
+      nav {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: #ffffff;
+        border-bottom: 1px solid #f2f4f6;
+        padding: 12px 0;
+      }
+
+      .nav-inner,
+      .page-container {
+        max-width: 1248px;
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 24px;
+        padding-right: 24px;
+        box-sizing: border-box;
+      }
+
+      .nav-inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .nav-logo img {
+        height: 32px;
+        width: auto;
+        display: block;
+      }
+
+      .nav-center {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .nav-item {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        font-family: 'Poppins', sans-serif;
+        font-size: 0.925rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        color: #6b7280;
+        cursor: pointer;
+        transition: all 0.2s;
+        border: none;
+        background: none;
+        text-decoration: none;
+      }
+
+      .nav-item:hover {
+        background: #f3f4f6;
+        color: #00263b;
+      }
+
+      .nav-right {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .btn-auth {
+        font-family: 'Poppins', sans-serif;
+        font-size: 0.85rem;
+        font-weight: 700;
+        padding: 8px 16px;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.2s;
+        text-decoration: none;
+      }
+
+      .btn-login {
+        color: #00263b;
+      }
+
+      .btn-login:hover {
+        background: #f3f4f6;
+      }
+
+      .btn-signup {
+        background: #00263b;
+        color: #fff;
+      }
+
+      .btn-signup:hover {
+        background: #001e2f;
+      }
+
+      .nav-mobile-top {
+        display: none;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .nav-hamburger {
+        width: 40px;
+        height: 40px;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        background: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+      }
+
+      .mobile-nav-panel {
+        display: none;
+      }
+
+      .mobile-nav-accordion-panel {
+        display: grid;
+        grid-template-rows: 0fr;
+        opacity: 0;
+        transition:
+          grid-template-rows 0.3s ease-out,
+          opacity 0.3s ease-out;
+      }
+      .mobile-nav-accordion-panel.is-open {
+        grid-template-rows: 1fr;
+        opacity: 1;
+      }
+      .mobile-nav-accordion-chevron {
+        transition: transform 0.3s ease;
+      }
+      .mobile-nav-accordion-toggle[aria-expanded='true']
+        .mobile-nav-accordion-chevron {
+        transform: rotate(180deg);
+      }
+
+      @media (max-width: 768px) {
+        .nav-inner {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+        }
+        .nav-center,
+        .nav-right,
+        .nav-desktop {
+          display: none;
+        }
+
+        .nav-mobile-top {
+          display: flex;
+          width: 100%;
+        }
+
+        .nav-logo {
+          display: none;
+        }
+
+        .mobile-nav-panel {
+          display: block;
+          width: 100%;
+          flex-basis: 100%;
+          overflow: hidden;
+          max-height: 0;
+          opacity: 0;
+          padding-top: 0;
+          pointer-events: none;
+          transition:
+            max-height 0.3s ease-out,
+            opacity 0.25s ease-out,
+            padding-top 0.25s ease-out;
+        }
+
+        .mobile-nav-panel.is-open {
+          max-height: 42rem;
+          opacity: 1;
+          padding-top: 12px;
+          pointer-events: auto;
+        }
+
+        .nav-hamburger [data-menu-close] {
+          display: none;
+        }
+
+        .nav-hamburger.is-open [data-menu-open] {
+          display: none;
+        }
+
+        .nav-hamburger.is-open [data-menu-close] {
+          display: block;
+        }
+      }
+
+      .card-shadow {
+        box-shadow: 0 10px 30px rgba(0, 38, 59, 0.08);
+      }
+
+      .pm-card-lift {
+        transition:
+          transform 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+
+      .pm-card-lift:hover {
+        transform: translateY(-8px);
+        box-shadow: 0 20px 40px rgba(0, 38, 59, 0.12);
+      }
+
+      /* Collapsible Cart Bottom Drawer */
+      #cart-drawer-details {
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+      }
+      #cart-drawer-details.is-open {
+        max-height: 400px;
+      }
+    </style>
+  </head>
+
+  <body
+    class="bg-surface font-body text-body antialiased min-h-screen flex flex-col"
+  >
+    <!-- Skip Link for Accessibility -->
+    <a
+      href="#main-content"
+      class="fixed left-4 top-4 z-[9999] -translate-y-[200%] rounded-2xl bg-navy px-4 py-3 text-sm font-bold text-white focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-teal"
+      >Skip to content</a
+    >
+
+    <!-- 1. NAVBAR -->
+    <nav>
+      <div class="nav-inner">
+        <!-- Desktop Logo -->
+        <a aria-label="Pacemaker home" class="nav-logo" href="../main.html">
+          <img
+            alt="Pacemaker Logo"
+            src="../../img/logo.webp"
+            style="height: 32px; width: auto; display: block"
+            onerror="this.src = '../../icons/paceup-logo-black.svg'"
+          />
+        </a>
+        <!-- Navigation Menu & Auth -->
+        <div class="nav-desktop flex items-center ml-auto">
+          <div class="nav-center">
+            <a class="nav-item" href="../workshops/workshop_list.html"
+              >Workshops</a
+            >
+            <a class="nav-item" href="../courses/course_list.html"
+              >Online Courses</a
+            >
+            <a class="nav-item" href="../ebooks/ebook_list.html">E-books</a>
+
+            <!-- Cart Button -->
+            <a href="cart.html" class="nav-item text-orange">
+              <span
+                class="flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[11px] font-extrabold shadow-sm"
+                >3</span
+              >
+              <span>Cart</span>
+            </a>
+
+            <!-- User Profile Dropdown -->
+            <div class="relative group" id="user-profile-menu">
+              <button
+                type="button"
+                id="user-profile-toggle"
+                class="nav-item focus:outline-none"
+                aria-expanded="false"
+              >
+                <span class="material-symbols-outlined text-[20px]"
+                  >account_circle</span
+                >
+                <span>Jamie</span>
+                <span
+                  class="material-symbols-outlined text-sm transition-transform group-hover:rotate-180"
+                  >expand_more</span
+                >
+              </button>
+
+              <!-- Dropdown Menu -->
+              <div
+                id="user-profile-dropdown"
+                class="absolute left-1/2 -translate-x-1/2 top-full mt-2 w-48 rounded-2xl bg-white p-2 shadow-2xl border border-gray-100 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50"
+              >
+                <a
+                  href="mypage.html"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >space_dashboard</span
+                  >
+                  <span>My Page</span>
+                </a>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >receipt_long</span
+                  >
+                  <span>Order History</span>
+                </a>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >settings</span
+                  >
+                  <span>Settings</span>
+                </a>
+                <div class="my-1 border-t border-gray-100"></div>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-red-500 hover:bg-red-50 transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg">logout</span>
+                  <span>Log Out</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+      <!-- Mobile Navigation Header -->
+      <div class="nav-mobile-top">
+        <a href="../main.html" class="flex-shrink-0" style="display: block">
+          <img
+            alt="Pacemaker Logo"
+            src="../../img/logo.webp"
+            style="height: 28px; width: auto; max-width: none; display: block"
+            onerror="this.src = '../../icons/paceup-logo-black.svg'"
+          />
+        </a>
+        <div class="flex items-center gap-2 flex-shrink-0">
+          <button
+            aria-controls="mobile-nav-menu"
+            aria-expanded="false"
+            aria-label="Open menu"
+            class="nav-hamburger"
+            id="mobile-nav-toggle"
+            type="button"
+          >
+            <svg
+              data-menu-open
+              fill="none"
+              height="18"
+              stroke="#00263b"
+              stroke-linecap="round"
+              stroke-width="2.5"
+              viewBox="0 0 24 24"
+              width="18"
+            >
+              <line x1="3" x2="21" y1="6" y2="6"></line>
+              <line x1="3" x2="21" y1="12" y2="12"></line>
+              <line x1="3" x2="21" y1="18" y2="18"></line>
+            </svg>
+            <svg
+              data-menu-close
+              fill="none"
+              height="18"
+              stroke="#00263b"
+              stroke-linecap="round"
+              stroke-width="2.5"
+              viewBox="0 0 24 24"
+              width="18"
+            >
+              <line x1="6" x2="18" y1="6" y2="18"></line>
+              <line x1="18" x2="6" y1="6" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+      </div>
+      <!-- Mobile Dropdown Panel -->
+      <div class="mobile-nav-panel" id="mobile-nav-menu">
+        <div class="rounded-none border border-gray-200 bg-white p-3">
+          <div class="border-t border-gray-100 pt-2">
+            <div class="py-1">
+              <a
+                class="flex items-center h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                href="../main.html"
+                ><span>HOME</span></a
+              >
+            </div>
+            <div class="py-1">
+              <button
+                type="button"
+                aria-expanded="false"
+                class="mobile-nav-accordion-toggle flex w-full items-center justify-between h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                data-target="mobile-nav-programs"
+              >
+                <span>PROGRAMS</span>
+                <svg
+                  class="mobile-nav-accordion-chevron w-4 h-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m6 9 6 6 6-6"></path>
+                </svg>
+              </button>
+              <div class="mobile-nav-accordion-panel" id="mobile-nav-programs">
+                <div class="overflow-hidden">
+                  <div class="flex flex-col gap-1">
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="../workshops/workshop_list.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >calendar_month</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Workshops</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Live sessions, practical events, and real-world
+                          feedback.
+                        </p>
+                      </div>
+                    </a>
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="../courses/course_list.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >play_lesson</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Online Courses</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Guided lessons to help with resumes, interviews, and
+                          career moves.
+                        </p>
+                      </div>
+                    </a>
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="../ebooks/ebook_list.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >menu_book</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >E-books</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Quick reads with practical tips for searching and
+                          applying with confidence.
+                        </p>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="py-1">
+              <button
+                type="button"
+                aria-expanded="false"
+                class="mobile-nav-accordion-toggle flex w-full items-center justify-between h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                data-target="mobile-nav-user-profile"
+              >
+                <span class="flex items-center gap-2">
+                  <span class="material-symbols-outlined text-[20px]"
+                    >account_circle</span
+                  >
+                  <span>JAMIE</span>
+                </span>
+                <svg
+                  class="mobile-nav-accordion-chevron w-4 h-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m6 9 6 6 6-6"></path>
+                </svg>
+              </button>
+              <div
+                class="mobile-nav-accordion-panel"
+                id="mobile-nav-user-profile"
+              >
+                <div class="overflow-hidden">
+                  <div class="flex flex-col gap-1">
+                    <!-- Cart -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5 font-bold text-orange"
+                      href="cart.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-orange/5 text-orange transition-colors shadow-sm border border-transparent"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >shopping_cart</span
+                        >
+                        <span
+                          class="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[10px] font-extrabold shadow-sm"
+                          >3</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-orange mb-0.5"
+                            >Cart</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-orange opacity-100 transition-all"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-orange/80 font-medium leading-snug line-clamp-2"
+                        >
+                          Check your selected courses and books.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- My Page -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="mypage.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >space_dashboard</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >My Page</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          View your statistics, courses, and settings.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Order History -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >receipt_long</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Order History</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Manage your purchases and receipt details.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Settings -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >settings</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Settings</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Configure account preferences and security.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Log Out -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-red-50"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-red-50 text-red-500 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-red-600 group-hover/item:border-red-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >logout</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-red-500 mb-0.5"
+                            >Log Out</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-red-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-red-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Safely sign out of your account.
+                        </p>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main Content Container -->
+    <main
+      id="main-content"
+      class="flex-1 max-w-[1248px] w-full mx-auto px-6 py-12"
+    >
+      <div class="flex flex-col lg:flex-row gap-8">
+        <!-- Left Sidebar -->
+        <aside class="w-full lg:w-[320px] shrink-0">
+          <div
+            class="bg-white rounded-none border border-gray-100 p-6 flex flex-col items-center shadow-card relative sticky top-28"
+          >
+            <!-- Settings Gear Button -->
+            <button
+              class="absolute top-4 right-4 p-2.5 text-body hover:text-orange rounded-2xl hover:bg-orange/10 transition-colors"
+              aria-label="Settings"
+              title="Settings"
+            >
+              <span class="material-symbols-outlined text-xl">settings</span>
+            </button>
+
+            <!-- Profile Avatar -->
+            <div
+              class="w-28 h-28 rounded-full border-4 border-orange/10 p-1 mb-4 shadow-sm relative"
+            >
+              <img
+                src="../../img/user3.png"
+                alt="Jamie"
+                class="w-full h-full object-cover rounded-full"
+                onerror="
+                  this.src =
+                    'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&auto=format&fit=crop&q=80'
+                "
+              />
+            </div>
+
+            <!-- Profile Name -->
+            <h2 class="text-xl font-bold text-navy font-headline mb-6">
+              Jamie
+            </h2>
+
+            <!-- Navigation Links -->
+            <nav
+              class="w-full flex flex-col gap-1 border-t border-gray-100 pt-4 !static !p-0 !border-none"
+            >
+              <!-- Inactive Item: My Account -->
+              <a
+                href="./mypage.html"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl">person</span>
+                <span>My Account</span>
+              </a>
+
+              <!-- Active Item: Cart -->
+              <a
+                href="./cart.html"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-bold text-orange bg-orange/10 border-l-4 border-orange font-headline transition-all"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >shopping_cart</span
+                >
+                <span>Cart</span>
+              </a>
+
+              <a
+                href="#"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl">favorite</span>
+                <span>Wish list</span>
+              </a>
+
+              <a
+                href="#"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >receipt_long</span
+                >
+                <span>Order History</span>
+              </a>
+
+              <a
+                href="#"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >support_agent</span
+                >
+                <span>Contact Us</span>
+              </a>
+            </nav>
+          </div>
+        </aside>
+
+        <!-- Right Main Dashboard Content (Cart Body) -->
+        <section class="flex-1 min-w-0">
+          <!-- Cart Header -->
+          <div>
+            <h1 class="text-3xl font-extrabold text-navy font-headline mb-6">
+              Cart
+            </h1>
+            <div
+              class="flex items-center justify-between border-b border-gray-200 pb-4"
+            >
+              <label class="flex items-center gap-1.5 sm:gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked
+                  class="h-4 w-4 sm:h-5 sm:w-5 rounded border-gray-300 text-orange focus:ring-orange cursor-pointer"
+                />
+                <span class="text-xs sm:text-sm font-semibold text-navy font-headline"
+                  >Select all</span
+                >
+              </label>
+              <button
+                type="button"
+                class="text-xs sm:text-sm font-bold text-gray-500 hover:text-orange border border-gray-200 px-3 py-1.5 sm:px-4 sm:py-2 rounded-2xl hover:border-orange transition-colors shrink-0"
+              >
+                Remove selected
+              </button>
+            </div>
+          </div>
+
+          <!-- Cart List -->
+          <div class="space-y-4 mt-6">
+            <!-- Cart Item 1 -->
+            <div
+              class="flex flex-col sm:flex-row items-start sm:items-center justify-between bg-white border border-gray-100 p-3 sm:p-4 shadow-card rounded-none gap-3 sm:gap-4"
+            >
+              <div class="flex items-center gap-3 sm:gap-4 w-full sm:w-auto">
+                <!-- Checkbox + Type tag -->
+                <div class="flex flex-col items-center gap-1.5 min-w-[50px] sm:min-w-[70px] shrink-0">
+                  <input
+                    type="checkbox"
+                    checked
+                    class="h-4 w-4 sm:h-5 sm:w-5 rounded border-gray-300 text-orange focus:ring-orange cursor-pointer"
+                  />
+                  <span
+                    class="text-[8px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center leading-tight"
+                    >Online<br />Courses</span
+                  >
+                </div>
+                <!-- Image -->
+                <img
+                  src="../../img/online-course-1.png"
+                  alt="Resume & Interview Essentials"
+                  class="w-16 h-12 sm:w-24 sm:h-16 rounded-none object-cover border border-gray-100 shrink-0"
+                />
+                <!-- Details -->
+                <div class="min-w-0 flex-1 flex flex-col justify-center self-center">
+                  <div class="mb-1">
+                    <span
+                      class="text-white text-[9px] sm:text-[10px] font-bold px-2 py-0.5 sm:px-2.5 sm:py-0.5 rounded-full uppercase tracking-wider"
+                      style="background: rgb(54, 166, 247)"
+                    >
+                      Interview
+                    </span>
+                  </div>
+                  <h3
+                    class="text-xs sm:text-base font-bold text-navy font-headline leading-tight line-clamp-2"
+                  >
+                    Resume & Interview Essentials
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="flex items-center justify-between sm:justify-end gap-6 w-full sm:w-auto pl-[62px] sm:pl-0 border-t sm:border-t-0 border-gray-100 pt-3 sm:pt-0"
+              >
+                <span class="text-lg sm:text-xl font-extrabold text-navy">$2800</span>
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-orange transition-colors"
+                >
+                  <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Cart Item 2 -->
+            <div
+              class="flex flex-col sm:flex-row items-start sm:items-center justify-between bg-white border border-gray-100 p-3 sm:p-4 shadow-card rounded-none gap-3 sm:gap-4"
+            >
+              <div class="flex items-center gap-3 sm:gap-4 w-full sm:w-auto">
+                <!-- Checkbox + Type tag -->
+                <div class="flex flex-col items-center gap-1.5 min-w-[50px] sm:min-w-[70px] shrink-0">
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 sm:h-5 sm:w-5 rounded border-gray-300 text-orange focus:ring-orange cursor-pointer"
+                  />
+                  <span
+                    class="text-[8px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-wider"
+                    >E-Books</span
+                  >
+                </div>
+                <!-- Styled CSS Book Cover Thumbnail -->
+                <div
+                  class="w-16 h-12 sm:w-24 sm:h-16 bg-[#FFF5F2] rounded-none flex flex-col justify-center px-1.5 py-0.5 sm:px-2 sm:py-1 select-none border border-orange/10 relative shrink-0"
+                >
+                  <span
+                    class="text-[4px] sm:text-[5px] font-extrabold uppercase text-[#FF6B3D] tracking-wider absolute top-0.5 left-1 sm:top-1 sm:left-2"
+                    >Networking</span
+                  >
+                  <h4
+                    class="text-[#FF6B3D] text-[7px] sm:text-[9px] font-extrabold font-headline leading-none mt-0.5 sm:mt-1"
+                  >
+                    Marketing
+                  </h4>
+                  <p
+                    class="text-[#FF6B3D] text-[4px] sm:text-[5px] font-semibold leading-none line-clamp-2 mt-0.5"
+                  >
+                    The 94% Success Formula
+                  </p>
+                </div>
+                <!-- Details -->
+                <div class="min-w-0 flex-1 flex flex-col justify-center self-center">
+                  <div class="mb-1">
+                    <span
+                      class="text-white text-[9px] sm:text-[10px] font-bold px-2 py-0.5 sm:px-2.5 sm:py-0.5 rounded-full uppercase tracking-wider"
+                      style="background: rgb(255, 126, 84)"
+                    >
+                      Marketing
+                    </span>
+                  </div>
+                  <h3
+                    class="text-xs sm:text-base font-bold text-navy font-headline leading-tight line-clamp-2"
+                  >
+                    Branding & Networking for Marketers
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="flex items-center justify-between sm:justify-end gap-6 w-full sm:w-auto pl-[62px] sm:pl-0 border-t sm:border-t-0 border-gray-100 pt-3 sm:pt-0"
+              >
+                <span class="text-lg sm:text-xl font-extrabold text-navy">$2800</span>
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-orange transition-colors"
+                >
+                  <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Cart Item 3 -->
+            <div
+              class="flex flex-col sm:flex-row items-start sm:items-center justify-between bg-white border border-gray-100 p-3 sm:p-4 shadow-card rounded-none gap-3 sm:gap-4"
+            >
+              <div class="flex items-center gap-3 sm:gap-4 w-full sm:w-auto">
+                <!-- Checkbox + Type tag -->
+                <div class="flex flex-col items-center gap-1.5 min-w-[50px] sm:min-w-[70px] shrink-0">
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 sm:h-5 sm:w-5 rounded border-gray-300 text-orange focus:ring-orange cursor-pointer"
+                  />
+                  <span
+                    class="text-[8px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-wider"
+                    >Workshops</span
+                  >
+                </div>
+                <!-- Image -->
+                <img
+                  src="../../img/workshop-1.png"
+                  alt="Mind Training for Success"
+                  class="w-16 h-12 sm:w-24 sm:h-16 rounded-none object-cover border border-gray-100 shrink-0"
+                />
+                <!-- Details -->
+                <div class="min-w-0 flex-1 flex flex-col justify-center self-center">
+                  <div class="mb-1">
+                    <span class="text-gray-400 text-[9px] sm:text-[10px] font-semibold">
+                      May 10, 2025
+                    </span>
+                  </div>
+                  <h3
+                    class="text-xs sm:text-base font-bold text-navy font-headline leading-tight line-clamp-2"
+                  >
+                    Mind Training for Success
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="flex items-center justify-between sm:justify-end gap-6 w-full sm:w-auto pl-[62px] sm:pl-0 border-t sm:border-t-0 border-gray-100 pt-3 sm:pt-0"
+              >
+                <span class="text-lg sm:text-xl font-extrabold text-navy">$20</span>
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-orange transition-colors"
+                >
+                  <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Cart Item 4 -->
+            <div
+              class="flex flex-col sm:flex-row items-start sm:items-center justify-between bg-white border border-gray-100 p-3 sm:p-4 shadow-card rounded-none gap-3 sm:gap-4"
+            >
+              <div class="flex items-center gap-3 sm:gap-4 w-full sm:w-auto">
+                <!-- Checkbox + Type tag -->
+                <div class="flex flex-col items-center gap-1.5 min-w-[50px] sm:min-w-[70px] shrink-0">
+                  <input
+                    type="checkbox"
+                    class="h-4 w-4 sm:h-5 sm:w-5 rounded border-gray-300 text-orange focus:ring-orange cursor-pointer"
+                  />
+                  <span
+                    class="text-[8px] sm:text-[10px] font-bold text-gray-400 uppercase tracking-wider text-center leading-tight"
+                    >Online<br />Courses</span
+                  >
+                </div>
+                <!-- Image -->
+                <img
+                  src="../../img/online-course-3.png"
+                  alt="Resume & Interview Essentials"
+                  class="w-16 h-12 sm:w-24 sm:h-16 rounded-none object-cover border border-gray-100 shrink-0"
+                />
+                <!-- Details -->
+                <div class="min-w-0 flex-1 flex flex-col justify-center self-center">
+                  <div class="mb-1">
+                    <span
+                      class="text-white text-[9px] sm:text-[10px] font-bold px-2 py-0.5 sm:px-2.5 sm:py-0.5 rounded-full uppercase tracking-wider"
+                      style="background: rgb(54, 166, 247)"
+                    >
+                      Interview
+                    </span>
+                  </div>
+                  <h3
+                    class="text-xs sm:text-base font-bold text-navy font-headline leading-tight line-clamp-2"
+                  >
+                    Resume & Interview Essentials
+                  </h3>
+                </div>
+              </div>
+              <div
+                class="flex items-center justify-between sm:justify-end gap-6 w-full sm:w-auto pl-[62px] sm:pl-0 border-t sm:border-t-0 border-gray-100 pt-3 sm:pt-0"
+              >
+                <span class="text-lg sm:text-xl font-extrabold text-navy">$2800</span>
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-orange transition-colors"
+                >
+                  <span class="material-symbols-outlined text-xl">close</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- You Might Also Like -->
+          <div class="pt-8">
+            <h2 class="text-xl font-bold font-headline text-navy mb-6">
+              You Might Also Like
+            </h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+              <!-- Recommendation 1 -->
+              <div
+                class="pm-card-lift group/ebook bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              >
+                <div>
+                  <div
+                    class="relative h-[180px] bg-[#FFF5F2] p-6 flex flex-col justify-start"
+                  >
+                    <div class="mb-3 flex items-center justify-between">
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                        style="background: rgb(255, 126, 84)"
+                      >
+                        Marketing
+                      </span>
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
+                        >E-books</span
+                      >
+                    </div>
+                    <div>
+                      <h4
+                        class="text-[#FF6B3D] text-xl font-extrabold font-headline leading-tight mb-1"
+                      >
+                        Marketing
+                      </h4>
+                      <p
+                        class="text-[#FF6B3D] text-[11px] font-medium leading-normal line-clamp-3"
+                      >
+                        The 94% Success Formula: A Proven Approach to Job &
+                        Career Transitions
+                      </p>
+                    </div>
+                  </div>
+                  <div class="p-5">
+                    <div class="flex justify-between items-start gap-3 mb-2">
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
+                      >
+                        Branding & Networking for Marketers
+                      </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
+                    </div>
+                    <p
+                      class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                    >
+                      Learn what truly matters in hiring criteria and how to
+                      build the right experience to strengthen your resume.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                >
+                  <span class="material-symbols-outlined text-[16px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+
+              <!-- Recommendation 2 -->
+              <div
+                class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              >
+                <div>
+                  <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                    <img
+                      src="../../img/online-course-1.png"
+                      alt="Resume + Interview Prep"
+                      class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                    />
+                    <div
+                      class="absolute top-6 left-6 right-6 z-10 flex items-center justify-between"
+                    >
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                        style="background: rgb(54, 166, 247)"
+                      >
+                        Interview
+                      </span>
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
+                        >Online courses</span
+                      >
+                    </div>
+                  </div>
+                  <div class="p-5">
+                    <div class="flex justify-between items-start gap-3 mb-2">
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
+                    </div>
+                    <p
+                      class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                    >
+                      This course helps you build transferable skills, craft
+                      strong resumes and personal statements, and prepare for
+                      interviews step by step.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                >
+                  <span class="material-symbols-outlined text-[16px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+
+              <!-- Recommendation 3 -->
+              <div
+                class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              >
+                <div>
+                  <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                    <img
+                      src="../../img/online-course-2.png"
+                      alt="Resume + Interview Prep"
+                      class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                    />
+                    <div
+                      class="absolute top-6 left-6 right-6 z-10 flex items-center justify-between"
+                    >
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                        style="background: rgb(245, 158, 11)"
+                      >
+                        Interview
+                      </span>
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
+                        >Online courses</span
+                      >
+                    </div>
+                  </div>
+                  <div class="p-5">
+                    <div class="flex justify-between items-start gap-3 mb-2">
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
+                    </div>
+                    <p
+                      class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                    >
+                      This course helps you build transferable skills, craft
+                      strong resumes and personal statements, and prepare for
+                      interviews step by step.
+                    </p>
+                  </div>
+                </div>
+                <button
+                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                >
+                  <span class="material-symbols-outlined text-[16px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer
+      class="bg-white border-t border-[#eaecf0] pt-[80px] pb-[60px] mt-auto"
+    >
+      <div class="page-container">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
+          <!-- Left: Logo + Social -->
+          <div>
+            <div class="mb-7">
+              <img
+                src="../../img/logo.webp"
+                alt="Pacemaker Logo"
+                class="h-8 w-auto block"
+                onerror="this.src = '../../icons/paceup-logo-black.svg'"
+              />
+            </div>
+            <p
+              class="text-[0.85rem] font-bold uppercase tracking-[0.16em] text-[#98a2b3] mb-4"
+            >
+              Social
+            </p>
+            <div class="flex gap-3 flex-wrap">
+              <a
+                href="https://www.instagram.com/pacemaker_career"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="Instagram"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                  <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+                  <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+                </svg>
+              </a>
+              <a
+                href="https://www.facebook.com/globalpacemaker"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="Facebook"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"
+                  />
+                </svg>
+              </a>
+              <a
+                href="https://www.youtube.com/channel/UCyc055VyNuwAMF27dd74smA"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="YouTube"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.54C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"
+                  />
+                  <polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" />
+                </svg>
+              </a>
+              <a
+                href="https://www.threads.com/@pacemaker_career"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center no-underline transition-all hover:border-navy hover:text-navy"
+                style="
+                  font-family: 'Poppins', sans-serif;
+                  font-weight: 800;
+                  font-size: 0.85rem;
+                  color: #344054;
+                "
+                aria-label="Threads"
+              >
+                @
+              </a>
+            </div>
+          </div>
+
+          <!-- Contact info -->
+          <div class="w-full md:ml-auto md:w-fit md:text-right">
+            <p
+              class="text-[0.85rem] font-bold uppercase tracking-[0.16em] text-[#98a2b3] mb-4 md:text-right"
+            >
+              Contact
+            </p>
+            <ul class="list-none flex flex-col gap-3 md:items-end p-0 m-0">
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path
+                    d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"
+                  />
+                  <polyline points="22,6 12,13 2,6" />
+                </svg>
+                <a
+                  href="mailto:Hello@pacemakerca.com"
+                  class="text-[#344054] no-underline hover:text-navy transition-colors"
+                  >Hello@pacemakerca.com</a
+                >
+              </li>
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path
+                    d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.61 3.44 2 2 0 0 1 3.6 1.27h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 8.96a16 16 0 0 0 6.13 6.13l.96-.96a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
+                  />
+                </svg>
+                <a
+                  href="tel:+16476120523"
+                  class="text-[#344054] no-underline hover:text-navy transition-colors"
+                  >+1 647-612-0523</a
+                >
+              </li>
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                <span>Toronto, ON, Canada</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <p class="text-[0.9rem] text-[#98a2b3]">
+          © 2026 Pacemaker. All rights reserved.
+        </p>
+      </div>
+    </footer>
+    <!-- Sticky Checkout Bar / Drawer -->
+    <div
+      id="cart-sticky-bar"
+      class="fixed bottom-0 left-0 right-0 z-[200] bg-white border-t border-[#eaecf0] shadow-[0_-8px_30px_rgba(0,38,59,0.06)]"
+    >
+      <!-- 1. Collapsible Drawer Content (Order Summary Details) - Spans Full Width bg-white -->
+      <div
+        id="cart-drawer-details"
+        class="max-h-0 overflow-hidden transition-all duration-300 ease-in-out border-b border-gray-100 bg-white"
+      >
+        <div class="max-w-[1248px] mx-auto px-4 sm:px-6 pb-6 pt-4 space-y-4 text-navy">
+          <!-- Centered Close Button Row (Vertically centered in the top gap) -->
+          <div class="flex justify-center items-center py-2">
+            <button
+              id="cart-drawer-close"
+              type="button"
+              class="text-xs font-bold text-gray-400 hover:text-orange flex items-center gap-1 transition-colors"
+            >
+              <span>Close</span>
+              <span class="material-symbols-outlined text-[16px]"
+                >keyboard_arrow_down</span
+              >
+            </button>
+          </div>
+
+          <div class="flex justify-between items-center">
+            <h3 class="text-base font-bold text-navy font-headline">
+              Order Summary
+            </h3>
+          </div>
+
+          <div
+            class="grid grid-cols-1 md:grid-cols-2 gap-8 items-start text-sm"
+          >
+            <!-- Pricing Breakdown -->
+            <div class="space-y-3">
+              <div class="flex justify-between text-body">
+                <span>Subtotal (3 courses)</span>
+                <span class="font-bold text-navy">$264.97</span>
+              </div>
+              <div class="flex justify-between text-[#ff4f02]">
+                <span>Discount</span>
+                <span class="font-bold">-$20.00</span>
+              </div>
+              <div class="flex justify-between text-body">
+                <span>Tax</span>
+                <span class="font-bold text-navy">$24.49</span>
+              </div>
+            </div>
+
+            <!-- Promo Code Input -->
+            <div class="space-y-2.5">
+              <span
+                class="text-xs font-bold text-navy uppercase tracking-wider block"
+                >Promo code</span
+              >
+              <div class="flex gap-2">
+                <input
+                  type="text"
+                  placeholder="Enter promo code"
+                  class="flex-1 bg-white border border-gray-200 text-sm px-3 py-2 focus:outline-none focus:ring-1 focus:ring-orange focus:border-orange rounded-none placeholder:text-gray-300 text-navy font-medium"
+                />
+                <button
+                  type="button"
+                  class="bg-[#00263b] hover:bg-[#001e2f] text-white text-xs font-bold px-4 py-2 transition-colors rounded-none"
+                >
+                  Apply
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2. Fixed Bar Bottom Row Wrapper - Spans Full Width bg-navy on both mobile and desktop -->
+      <div class="bg-navy text-white border-t border-navy/10 shadow-[0_-8px_30px_rgba(0,38,59,0.15)] pb-3 sm:pb-0">
+        <div class="max-w-[1248px] mx-auto px-4 sm:px-6 py-5 sm:py-4 flex items-center justify-between relative">
+          <!-- Total Price display (Stacked vertically on mobile to prevent overlapping) -->
+          <div class="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2 shrink-0">
+            <span
+              class="text-[10px] sm:text-xs font-bold text-white/80 uppercase tracking-wider leading-none"
+              >Total</span
+            >
+            <span
+              class="text-lg sm:text-2xl font-extrabold text-white font-headline leading-none"
+              >$269.46</span
+            >
+          </div>
+
+          <!-- Centered Toggle Button -->
+          <div
+            class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10"
+            id="cart-drawer-toggle-wrapper"
+          >
+            <button
+              id="cart-drawer-toggle"
+              type="button"
+              class="text-xs font-bold text-white/80 hover:text-white flex items-center gap-0.5 sm:gap-1 transition-all"
+            >
+              <span>View details</span>
+              <span
+                class="material-symbols-outlined text-[14px] sm:text-[16px] transition-transform"
+                id="toggle-chevron"
+                >keyboard_arrow_up</span
+              >
+            </button>
+          </div>
+
+          <!-- Checkout Button -->
+          <button
+            type="button"
+            class="bg-[#ff4f02] hover:bg-[#e04400] text-white font-extrabold text-xs sm:text-sm px-5 sm:px-10 py-2.5 sm:py-3 rounded-full transition-colors shadow-md shadow-orange/20 z-10"
+          >
+            Checkout
+          </button>
+        </div>
+      </div>
+    </div>
+
+
+
+
+
+    <!-- Mobile Nav Script -->
+    <script>
+      (function mobileNav() {
+        var menuToggle = document.getElementById('mobile-nav-toggle');
+        var menu = document.getElementById('mobile-nav-menu');
+        if (!menuToggle || !menu) return;
+
+        function setMenuOpen(isOpen) {
+          menu.classList.toggle('is-open', isOpen);
+          menuToggle.classList.toggle('is-open', isOpen);
+          menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+          menuToggle.setAttribute(
+            'aria-label',
+            isOpen ? 'Close menu' : 'Open menu'
+          );
+        }
+
+        menuToggle.addEventListener('click', function () {
+          setMenuOpen(!menu.classList.contains('is-open'));
+        });
+
+        document.addEventListener('click', function (event) {
+          if (!menu.classList.contains('is-open')) return;
+          if (menu.contains(event.target) || menuToggle.contains(event.target))
+            return;
+          setMenuOpen(false);
+        });
+
+        document.addEventListener('keydown', function (event) {
+          if (event.key === 'Escape') {
+            setMenuOpen(false);
+          }
+        });
+
+        window.addEventListener('resize', function () {
+          if (window.innerWidth > 768) {
+            setMenuOpen(false);
+          }
+        });
+
+        Array.prototype.forEach.call(
+          document.querySelectorAll('.mobile-nav-accordion-toggle'),
+          function (toggle) {
+            var panelId = toggle.getAttribute('data-target');
+            var panel = panelId ? document.getElementById(panelId) : null;
+            if (!panel) return;
+
+            toggle.addEventListener('click', function () {
+              var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+              panel.classList.toggle('is-open', !isOpen);
+            });
+          }
+        );
+      })();
+
+      (function userProfileDropdown() {
+        var toggle = document.getElementById('user-profile-toggle');
+        var dropdown = document.getElementById('user-profile-dropdown');
+        var menu = document.getElementById('user-profile-menu');
+        if (!toggle || !dropdown || !menu) return;
+
+        toggle.addEventListener('click', function (e) {
+          e.stopPropagation();
+          var isOpen = dropdown.classList.contains('!opacity-100');
+          if (isOpen) {
+            dropdown.classList.remove('!opacity-100', '!visible');
+          } else {
+            dropdown.classList.add('!opacity-100', '!visible');
+          }
+        });
+
+        document.addEventListener('click', function (e) {
+          if (!menu.contains(e.target)) {
+            dropdown.classList.remove('!opacity-100', '!visible');
+          }
+        });
+      })();
+
+      (function cartDrawer() {
+        var toggleBtn = document.getElementById('cart-drawer-toggle');
+        var closeBtn = document.getElementById('cart-drawer-close');
+        var toggleWrapper = document.getElementById(
+          'cart-drawer-toggle-wrapper'
+        );
+        var detailsPanel = document.getElementById('cart-drawer-details');
+
+        if (!toggleBtn || !closeBtn || !detailsPanel || !toggleWrapper) return;
+
+        toggleBtn.addEventListener('click', function () {
+          detailsPanel.classList.add('is-open');
+          toggleWrapper.classList.add('invisible');
+        });
+
+        closeBtn.addEventListener('click', function () {
+          detailsPanel.classList.remove('is-open');
+          toggleWrapper.classList.remove('invisible');
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -244,7 +244,8 @@
         }
 
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -1490,7 +1491,7 @@
           </div>
         </div>
         <p class="text-[0.9rem] text-[#98a2b3]">
-          © 2026 Pacemaker. All rights reserved.
+          ÃƒÆ’Ã†â€™Ãƒâ€ Ã¢â‚¬â„¢ÃƒÆ’Ã‚Â¢ÃƒÂ¢Ã¢â‚¬Å¡Ã‚Â¬Ãƒâ€¦Ã‚Â¡ÃƒÆ’Ã¢â‚¬Å¡Ãƒâ€šÃ‚Â© 2026 Pacemaker. All rights reserved.
         </p>
       </div>
     </footer>
@@ -1504,21 +1505,7 @@
         id="cart-drawer-details"
         class="max-h-0 overflow-hidden transition-all duration-300 ease-in-out border-b border-gray-100 bg-white"
       >
-        <div class="max-w-[1248px] mx-auto px-4 sm:px-6 pb-6 pt-4 space-y-4 text-navy">
-          <!-- Centered Close Button Row (Vertically centered in the top gap) -->
-          <div class="flex justify-center items-center py-2">
-            <button
-              id="cart-drawer-close"
-              type="button"
-              class="text-xs font-bold text-gray-400 hover:text-orange flex items-center gap-1 transition-colors"
-            >
-              <span>Close</span>
-              <span class="material-symbols-outlined text-[16px]"
-                >keyboard_arrow_down</span
-              >
-            </button>
-          </div>
-
+        <div class="max-w-[1248px] mx-auto px-4 sm:px-6 pb-6 pt-6 space-y-4 text-navy">
           <div class="flex justify-between items-center">
             <h3 class="text-base font-bold text-navy font-headline">
               Order Summary
@@ -1569,29 +1556,20 @@
       </div>
 
       <!-- 2. Fixed Bar Bottom Row Wrapper - Spans Full Width bg-navy on both mobile and desktop -->
-      <div class="bg-navy text-white border-t border-navy/10 shadow-[0_-8px_30px_rgba(0,38,59,0.15)] pb-3 sm:pb-0">
-        <div class="max-w-[1248px] mx-auto px-4 sm:px-6 py-5 sm:py-4 flex items-center justify-between relative">
-          <!-- Total Price display (Stacked vertically on mobile to prevent overlapping) -->
-          <div class="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-2 shrink-0">
-            <span
-              class="text-[10px] sm:text-xs font-bold text-white/80 uppercase tracking-wider leading-none"
-              >Total</span
-            >
-            <span
-              class="text-lg sm:text-2xl font-extrabold text-white font-headline leading-none"
-              >$269.46</span
-            >
-          </div>
+      <div class="bg-navy text-white border-t border-navy/10 shadow-[0_-8px_30px_rgba(0,38,59,0.15)]">
+        <div
+          class="max-w-[1248px] mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4 relative"
+        >
+          <div class="w-[108px] shrink-0" aria-hidden="true"></div>
 
-          <!-- Centered Toggle Button -->
           <div
-            class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10"
             id="cart-drawer-toggle-wrapper"
+            class="absolute left-1/2 -translate-x-1/2 flex shrink-0"
           >
             <button
               id="cart-drawer-toggle"
               type="button"
-              class="text-xs font-bold text-white/80 hover:text-white flex items-center gap-0.5 sm:gap-1 transition-all"
+              class="text-xs font-bold text-white/70 hover:text-white flex items-center gap-1 transition-all whitespace-nowrap"
             >
               <span>View details</span>
               <span
@@ -1602,13 +1580,29 @@
             </button>
           </div>
 
-          <!-- Checkout Button -->
-          <button
-            type="button"
-            class="bg-[#ff4f02] hover:bg-[#e04400] text-white font-extrabold text-xs sm:text-sm px-5 sm:px-10 py-2.5 sm:py-3 rounded-full transition-colors shadow-md shadow-orange/20 z-10"
+          <div
+            class="ml-auto flex items-center justify-end gap-3 sm:gap-5 shrink-0"
           >
-            Checkout
-          </button>
+            <div
+              class="flex flex-col sm:flex-row sm:items-center gap-0.5 sm:gap-3 text-right"
+            >
+              <span
+                class="text-[10px] sm:text-xs font-bold text-white/65 uppercase tracking-[0.22em] leading-none"
+                >Total</span
+              >
+              <span
+                class="text-lg sm:text-3xl font-extrabold text-white font-headline leading-none"
+                >$269.46</span
+              >
+            </div>
+
+            <button
+              type="button"
+              class="bg-[#ff4f02] hover:bg-[#e04400] text-white font-extrabold text-xs sm:text-sm px-5 sm:px-8 py-2.5 sm:py-3 rounded-full transition-all shadow-[0_12px_24px_rgba(255,79,2,0.28)] whitespace-nowrap shrink-0"
+            >
+              Checkout
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -1666,6 +1660,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });
@@ -1698,24 +1707,29 @@
 
       (function cartDrawer() {
         var toggleBtn = document.getElementById('cart-drawer-toggle');
-        var closeBtn = document.getElementById('cart-drawer-close');
-        var toggleWrapper = document.getElementById(
-          'cart-drawer-toggle-wrapper'
-        );
         var detailsPanel = document.getElementById('cart-drawer-details');
+        var toggleLabel = toggleBtn ? toggleBtn.querySelector('span') : null;
+        var toggleChevron = document.getElementById('toggle-chevron');
 
-        if (!toggleBtn || !closeBtn || !detailsPanel || !toggleWrapper) return;
+        if (!toggleBtn || !detailsPanel || !toggleLabel || !toggleChevron) return;
+
+        function setDrawerOpen(isOpen) {
+          detailsPanel.classList.toggle('is-open', isOpen);
+          toggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+          toggleLabel.textContent = isOpen ? 'Close' : 'View details';
+          toggleChevron.textContent = isOpen
+            ? 'keyboard_arrow_down'
+            : 'keyboard_arrow_up';
+        }
 
         toggleBtn.addEventListener('click', function () {
-          detailsPanel.classList.add('is-open');
-          toggleWrapper.classList.add('invisible');
+          var isOpen = toggleBtn.getAttribute('aria-expanded') === 'true';
+          setDrawerOpen(!isOpen);
         });
 
-        closeBtn.addEventListener('click', function () {
-          detailsPanel.classList.remove('is-open');
-          toggleWrapper.classList.remove('invisible');
-        });
+        setDrawerOpen(false);
       })();
     </script>
   </body>
 </html>
+

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -396,7 +396,7 @@
                   <span>My Page</span>
                 </a>
                 <a
-                  href="#"
+                  href="./order_history.html"
                   class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
                 >
                   <span class="material-symbols-outlined text-lg"
@@ -709,7 +709,7 @@
                     <!-- Order History -->
                     <a
                       class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
-                      href="#"
+                      href="./order_history.html"
                     >
                       <div
                         class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
@@ -878,7 +878,7 @@
               </a>
 
               <a
-                href="#"
+                href="./order_history.html"
                 class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl"

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -285,8 +285,38 @@
         overflow: hidden;
         transition: max-height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
       }
-      #cart-drawer-details.is-open {
-        max-height: 400px;
+      /* Save: outline heart → filled on hover */
+      .favorite-heart .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        color: #9ca3af;
+        transition:
+          color 0.3s ease,
+          font-variation-settings 0.45s cubic-bezier(0.33, 1, 0.53, 1);
+      }
+      @media (hover: hover) {
+        .favorite-heart:hover .material-symbols-outlined {
+          font-variation-settings:
+            'FILL' 1,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+          color: #ff4f02;
+        }
+        .favorite-heart--liked:hover .material-symbols-outlined {
+          color: #e04400;
+        }
+      }
+      .favorite-heart--liked .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 1,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        color: #ff4f02;
       }
     </style>
   </head>
@@ -840,7 +870,7 @@
               </a>
 
               <a
-                href="#"
+                href="wishlist.html"
                 class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl">favorite</span>
@@ -1135,17 +1165,23 @@
                   <div
                     class="relative h-[180px] bg-[#FFF5F2] p-6 flex flex-col justify-start"
                   >
-                    <div class="mb-3 flex items-center justify-between">
+                    <!-- Liked heart button -->
+                    <button
+                      type="button"
+                      class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                      aria-label="Remove from wishlist"
+                    >
+                      <span class="material-symbols-outlined text-xl"
+                        >favorite</span
+                      >
+                    </button>
+                    <div class="mb-3">
                       <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                        class="inline-flex w-fit items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
                         style="background: rgb(255, 126, 84)"
                       >
                         Marketing
                       </span>
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
-                        >E-books</span
-                      >
                     </div>
                     <div>
                       <h4
@@ -1163,11 +1199,18 @@
                   </div>
                   <div class="p-5">
                     <div class="flex justify-between items-start gap-3 mb-2">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Branding & Networking for Marketers
-                      </h3>
+                      <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-2">
+                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                            >E-books</span
+                          >
+                        </div>
+                        <h3
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        >
+                          Branding & Networking for Marketers
+                        </h3>
+                      </div>
                       <span class="text-base font-extrabold text-navy"
                         >$2800</span
                       >
@@ -1180,14 +1223,16 @@
                     </p>
                   </div>
                 </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
                 <button
-                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
                 >
-                  <span class="material-symbols-outlined text-[16px]"
+                  <span class="material-symbols-outlined text-[18px]"
                     >shopping_cart</span
                   >
                   <span>Add to cart</span>
                 </button>
+              </div>
               </div>
 
               <!-- Recommendation 2 -->
@@ -1201,28 +1246,37 @@
                       alt="Resume + Interview Prep"
                       class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
                     />
-                    <div
-                      class="absolute top-6 left-6 right-6 z-10 flex items-center justify-between"
+                    <!-- Wishlist heart button -->
+                    <button
+                      type="button"
+                      class="favorite-heart absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                      aria-label="Add to wishlist"
                     >
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                        style="background: rgb(54, 166, 247)"
+                      <span class="material-symbols-outlined text-xl"
+                        >favorite</span
                       >
-                        Interview
-                      </span>
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
-                        >Online courses</span
-                      >
-                    </div>
+                    </button>
+                    <span
+                      class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                      style="background: rgb(54, 166, 247)"
+                    >
+                      Interview
+                    </span>
                   </div>
                   <div class="p-5">
                     <div class="flex justify-between items-start gap-3 mb-2">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
+                      <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-2">
+                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                            >Online courses</span
+                          >
+                        </div>
+                        <h3
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        >
+                          Resume + Interview Prep (All-in-One)
+                        </h3>
+                      </div>
                       <span class="text-base font-extrabold text-navy"
                         >$2800</span
                       >
@@ -1236,14 +1290,16 @@
                     </p>
                   </div>
                 </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
                 <button
-                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
                 >
-                  <span class="material-symbols-outlined text-[16px]"
+                  <span class="material-symbols-outlined text-[18px]"
                     >shopping_cart</span
                   >
                   <span>Add to cart</span>
                 </button>
+              </div>
               </div>
 
               <!-- Recommendation 3 -->
@@ -1257,28 +1313,37 @@
                       alt="Resume + Interview Prep"
                       class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
                     />
-                    <div
-                      class="absolute top-6 left-6 right-6 z-10 flex items-center justify-between"
+                    <!-- Wishlist heart button -->
+                    <button
+                      type="button"
+                      class="favorite-heart absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                      aria-label="Add to wishlist"
                     >
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                        style="background: rgb(245, 158, 11)"
+                      <span class="material-symbols-outlined text-xl"
+                        >favorite</span
                       >
-                        Interview
-                      </span>
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[10px] font-bold uppercase tracking-wider bg-black/40 backdrop-blur-sm px-2.5 h-[22px] rounded-full shadow-sm"
-                        >Online courses</span
-                      >
-                    </div>
+                    </button>
+                    <span
+                      class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                      style="background: rgb(245, 158, 11)"
+                    >
+                      Interview
+                    </span>
                   </div>
                   <div class="p-5">
                     <div class="flex justify-between items-start gap-3 mb-2">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
+                      <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-2">
+                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                            >Online courses</span
+                          >
+                        </div>
+                        <h3
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        >
+                          Resume + Interview Prep (All-in-One)
+                        </h3>
+                      </div>
                       <span class="text-base font-extrabold text-navy"
                         >$2800</span
                       >
@@ -1292,14 +1357,16 @@
                     </p>
                   </div>
                 </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
                 <button
-                  class="w-full flex items-center justify-center gap-2 border-t border-gray-100 py-3.5 text-xs font-bold text-navy hover:text-orange hover:bg-orange/5 transition-colors mt-auto"
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
                 >
-                  <span class="material-symbols-outlined text-[16px]"
+                  <span class="material-symbols-outlined text-[18px]"
                     >shopping_cart</span
                   >
                   <span>Add to cart</span>
                 </button>
+              </div>
               </div>
             </div>
           </div>
@@ -1728,6 +1795,16 @@
         });
 
         setDrawerOpen(false);
+      })();
+
+      (function favoriteHeartInit() {
+        var heartButtons = document.querySelectorAll('.favorite-heart');
+        heartButtons.forEach(function (heart) {
+          heart.addEventListener('click', function (e) {
+            e.stopPropagation();
+            heart.classList.toggle('favorite-heart--liked');
+          });
+        });
       })();
     </script>
   </body>

--- a/public/html/mypage/cart.html
+++ b/public/html/mypage/cart.html
@@ -1198,22 +1198,22 @@
                     </div>
                   </div>
                   <div class="p-5">
-                    <div class="flex justify-between items-start gap-3 mb-2">
-                      <div class="flex flex-col gap-1">
-                        <div class="flex items-center gap-2">
-                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                            >E-books</span
-                          >
-                        </div>
+                    <div class="flex flex-col gap-1 mb-2">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >E-books</span
+                        >
+                      </div>
+                      <div class="flex justify-between items-start gap-3">
                         <h3
-                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                         >
                           Branding & Networking for Marketers
                         </h3>
+                        <span class="text-base font-extrabold text-navy"
+                          >$2800</span
+                        >
                       </div>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
                     </div>
                     <p
                       class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1264,22 +1264,22 @@
                     </span>
                   </div>
                   <div class="p-5">
-                    <div class="flex justify-between items-start gap-3 mb-2">
-                      <div class="flex flex-col gap-1">
-                        <div class="flex items-center gap-2">
-                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                            >Online courses</span
-                          >
-                        </div>
+                    <div class="flex flex-col gap-1 mb-2">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <div class="flex justify-between items-start gap-3">
                         <h3
-                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                         >
                           Resume + Interview Prep (All-in-One)
                         </h3>
+                        <span class="text-base font-extrabold text-navy"
+                          >$2800</span
+                        >
                       </div>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
                     </div>
                     <p
                       class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1331,22 +1331,22 @@
                     </span>
                   </div>
                   <div class="p-5">
-                    <div class="flex justify-between items-start gap-3 mb-2">
-                      <div class="flex flex-col gap-1">
-                        <div class="flex items-center gap-2">
-                          <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                            >Online courses</span
-                          >
-                        </div>
+                    <div class="flex flex-col gap-1 mb-2">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <div class="flex justify-between items-start gap-3">
                         <h3
-                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                          class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                         >
                           Resume + Interview Prep (All-in-One)
                         </h3>
+                        <span class="text-base font-extrabold text-navy"
+                          >$2800</span
+                        >
                       </div>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
                     </div>
                     <p
                       class="text-xs text-body leading-relaxed line-clamp-3 mb-4"

--- a/public/html/mypage/mypage.html
+++ b/public/html/mypage/mypage.html
@@ -392,7 +392,7 @@
             <a class="nav-item" href="../ebooks/ebook_list.html">E-books</a>
 
             <!-- Cart Button -->
-            <a href="#" class="nav-item">
+            <a href="cart.html" class="nav-item">
               <span
                 class="flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[11px] font-extrabold shadow-sm"
                 >3</span
@@ -653,18 +653,197 @@
               </div>
             </div>
             <div class="py-1">
-              <a
-                class="flex items-center h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
-                href="#"
-                ><span>LOGIN</span></a
+              <button
+                type="button"
+                aria-expanded="false"
+                class="mobile-nav-accordion-toggle flex w-full items-center justify-between h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                data-target="mobile-nav-user-profile"
               >
-            </div>
-            <div class="pt-3">
-              <a
-                class="inline-flex w-full items-center justify-center rounded-2xl bg-navy px-6 py-4 text-sm font-bold text-white transition-colors hover:bg-[#001e2f]"
-                href="#"
-                >SIGN UP</a
+                <span class="flex items-center gap-2">
+                  <span class="material-symbols-outlined text-[20px]"
+                    >account_circle</span
+                  >
+                  <span>JAMIE</span>
+                </span>
+                <svg
+                  class="mobile-nav-accordion-chevron w-4 h-4"
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="m6 9 6 6 6-6"></path>
+                </svg>
+              </button>
+              <div
+                class="mobile-nav-accordion-panel"
+                id="mobile-nav-user-profile"
               >
+                <div class="overflow-hidden">
+                  <div class="flex flex-col gap-1">
+                    <!-- Cart -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="cart.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100 relative"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >shopping_cart</span
+                        >
+                        <span
+                          class="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[10px] font-extrabold shadow-sm"
+                          >3</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Cart</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Check your selected courses and books.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- My Page -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="mypage.html"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >space_dashboard</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >My Page</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          View your statistics, courses, and settings.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Order History -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >receipt_long</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Order History</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Manage your purchases and receipt details.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Settings -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >settings</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-navy mb-0.5"
+                            >Settings</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Configure account preferences and security.
+                        </p>
+                      </div>
+                    </a>
+                    <!-- Log Out -->
+                    <a
+                      class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-red-50"
+                      href="#"
+                    >
+                      <div
+                        class="mt-0.5 p-2 rounded-lg bg-red-50 text-red-500 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-red-600 group-hover/item:border-red-100"
+                      >
+                        <span class="material-symbols-outlined text-[20px]"
+                          >logout</span
+                        >
+                      </div>
+                      <div class="flex-1">
+                        <div class="flex items-center justify-between">
+                          <span
+                            class="text-[0.95rem] font-bold text-red-500 mb-0.5"
+                            >Log Out</span
+                          >
+                          <span
+                            class="material-symbols-outlined text-[18px] text-red-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                            >chevron_right</span
+                          >
+                        </div>
+                        <p
+                          class="text-[0.825rem] text-red-400 font-medium leading-snug line-clamp-2"
+                        >
+                          Safely sign out of your account.
+                        </p>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -678,7 +857,7 @@
     >
       <div class="flex flex-col lg:flex-row gap-8">
         <!-- Left Sidebar -->
-        <aside class="w-full lg:w-80 shrink-0">
+        <aside class="w-full lg:w-[320px] shrink-0">
           <div
             class="bg-white rounded-none border border-gray-100 p-6 flex flex-col items-center shadow-card relative sticky top-28"
           >
@@ -725,7 +904,7 @@
               </a>
 
               <a
-                href="#"
+                href="cart.html"
                 class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl"

--- a/public/html/mypage/mypage.html
+++ b/public/html/mypage/mypage.html
@@ -434,7 +434,7 @@
                   <span>My Page</span>
                 </a>
                 <a
-                  href="#"
+                  href="./order_history.html"
                   class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
                 >
                   <span class="material-symbols-outlined text-lg"
@@ -755,7 +755,7 @@
                     <!-- Order History -->
                     <a
                       class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
-                      href="#"
+                      href="./order_history.html"
                     >
                       <div
                         class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
@@ -923,7 +923,7 @@
               </a>
 
               <a
-                href="#"
+                href="./order_history.html"
                 class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl"

--- a/public/html/mypage/mypage.html
+++ b/public/html/mypage/mypage.html
@@ -244,7 +244,8 @@
         }
 
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -2122,6 +2123,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/mypage/mypage.html
+++ b/public/html/mypage/mypage.html
@@ -915,7 +915,7 @@
               </a>
 
               <a
-                href="#"
+                href="wishlist.html"
                 class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl">favorite</span>

--- a/public/html/mypage/order_history.html
+++ b/public/html/mypage/order_history.html
@@ -7,7 +7,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pacemaker | My Wishlist</title>
+    <title>Pacemaker | Order History</title>
 
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
 
@@ -445,7 +445,7 @@
                   <span>My Page</span>
                 </a>
                 <a
-                  href="./order_history.html"
+                  href="#"
                   class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
                 >
                   <span class="material-symbols-outlined text-lg"
@@ -761,7 +761,7 @@
                       <!-- Order History -->
                       <a
                         class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
-                        href="./order_history.html"
+                        href="#"
                       >
                         <div
                           class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
@@ -922,19 +922,19 @@
                 <span>Cart</span>
               </a>
 
-              <!-- Active Item: Wish list -->
+              <!-- Inactive Item: Wish list -->
               <a
                 href="./wishlist.html"
-                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-bold text-orange bg-orange/10 border-l-4 border-orange font-headline transition-all"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
               >
                 <span class="material-symbols-outlined text-xl">favorite</span>
                 <span>Wish list</span>
               </a>
 
-              <!-- Inactive Item: Order History -->
+              <!-- Active Item: Order History -->
               <a
                 href="./order_history.html"
-                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-bold text-orange bg-orange/10 border-l-4 border-orange font-headline transition-all"
               >
                 <span class="material-symbols-outlined text-xl"
                   >receipt_long</span
@@ -956,522 +956,319 @@
           </div>
         </aside>
 
-        <!-- Right Main Content: My Wishlist -->
-        <section class="flex-1 min-w-0">
-          <div class="mb-6">
+        <!-- Right Main Content: Order History -->
+        <section
+          class="flex-1 min-w-0 bg-white p-6 border border-gray-100 shadow-card rounded-none"
+        >
+          <div class="mb-4">
             <h1
-              class="text-[1.85rem] font-bold text-navy font-headline tracking-tight mb-6"
+              class="text-[1.85rem] font-bold text-navy font-headline tracking-tight"
             >
-              My Wishlist
+              Order History
             </h1>
-
-            <!-- Category Filter Tabs -->
-            <div class="flex flex-wrap gap-3 mb-8">
-              <button
-                class="course-filter-button is-active"
-                type="button"
-                aria-pressed="true"
-                data-filter="all"
-              >
-                All
-              </button>
-              <button
-                class="course-filter-button"
-                type="button"
-                aria-pressed="false"
-                data-filter="online-courses"
-              >
-                Online courses
-              </button>
-              <button
-                class="course-filter-button"
-                type="button"
-                aria-pressed="false"
-                data-filter="e-books"
-              >
-                E-books
-              </button>
-              <button
-                class="course-filter-button"
-                type="button"
-                aria-pressed="false"
-                data-filter="workshops"
-              >
-                Workshops
-              </button>
-            </div>
           </div>
 
-          <!-- Wishlist Grid -->
-          <div
-            id="wishlistGrid"
-            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
-          >
-            <!-- Card 1 (Online Course) -->
+          <!-- Order History List -->
+          <div class="border-t border-gray-200 mt-4">
+            <!-- Order 1 -->
             <div
-              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="online-courses"
+              class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-5 border-b border-gray-soft last:border-b-0"
             >
-              <div>
-                <div class="relative h-[180px] overflow-hidden bg-navy/5">
-                  <img
-                    src="../../img/online-course-1.png"
-                    alt="Resume + Interview Prep"
-                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
-                  />
-                  <!-- Liked heart button -->
-                  <button
-                    type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
-                  >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
-                    >
-                  </button>
-                  <span
-                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                    style="background: rgb(54, 166, 247)"
-                  >
-                    interview
-                  </span>
-                </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >Online courses</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
-                  >
-                    This course helps you build transferable skills, craft
-                    strong resumes and personal statements, and prepare for
-                    interviews step by step.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
-                >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
-                  >
-                  <span>Add to cart</span>
-                </button>
-              </div>
-            </div>
-
-            <!-- Card 2 (Online Course) -->
-            <div
-              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="online-courses"
-            >
-              <div>
-                <div class="relative h-[180px] overflow-hidden bg-navy/5">
-                  <img
-                    src="../../img/online-course-1.png"
-                    alt="Resume + Interview Prep"
-                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
-                  />
-                  <!-- Liked heart button -->
-                  <button
-                    type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
-                  >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
-                    >
-                  </button>
-                  <span
-                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                    style="background: rgb(54, 166, 247)"
-                  >
-                    Interview
-                  </span>
-                </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >Online courses</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
-                  >
-                    This course helps you build transferable skills, craft
-                    strong resumes and personal statements, and prepare for
-                    interviews step by step.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
-                >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
-                  >
-                  <span>Add to cart</span>
-                </button>
-              </div>
-            </div>
-
-            <!-- Card 3 (Online Course) -->
-            <div
-              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="online-courses"
-            >
-              <div>
-                <div class="relative h-[180px] overflow-hidden bg-navy/5">
-                  <img
-                    src="../../img/online-course-2.png"
-                    alt="Resume + Interview Prep"
-                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
-                  />
-                  <!-- Liked heart button -->
-                  <button
-                    type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
-                  >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
-                    >
-                  </button>
-                  <span
-                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                    style="background: rgb(245, 158, 11)"
-                  >
-                    Networking
-                  </span>
-                </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >Online courses</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
-                  >
-                    This course helps you build transferable skills, craft
-                    strong resumes and personal statements, and prepare for
-                    interviews step by step.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
-                >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
-                  >
-                  <span>Add to cart</span>
-                </button>
-              </div>
-            </div>
-
-            <!-- Card 4 (E-book) -->
-            <div
-              class="pm-card-lift group/ebook bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="e-books"
-            >
-              <div>
+              <div class="flex-1 min-w-0">
                 <div
-                  class="relative h-[180px] bg-[#FFF5F2] p-6 flex flex-col justify-start"
+                  class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-gray-400 mb-1.5 font-medium font-body"
                 >
-                  <!-- Liked heart button -->
-                  <button
-                    type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
-                  >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
-                    >
-                  </button>
-                  <span
-                    class="mb-3 inline-flex w-fit items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                    style="background: rgb(255, 126, 84)"
-                  >
-                    Marketing
-                  </span>
-                  <div>
-                    <h4
-                      class="text-[#FF6B3D] text-xl font-extrabold font-headline leading-tight mb-1"
-                    >
-                      Marketing
-                    </h4>
-                    <p
-                      class="text-[#FF6B3D] text-[11px] font-medium leading-normal line-clamp-3 pr-6"
-                    >
-                      The 94% Success Formula: A Proven Approach to Job & Career
-                      Transitions
-                    </p>
-                  </div>
+                  <span class="whitespace-nowrap">Placed on 0000-00-00</span>
+                  <span class="whitespace-nowrap">Order no. AAA1000001</span>
                 </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >E-books</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Branding & Networking for Marketers
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
-                  >
-                    Learn what truly matters in hiring criteria and how to build
-                    the right experience to strengthen your resume.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                <h3
+                  class="text-[17px] font-bold text-navy font-headline tracking-tight mb-1.5"
                 >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
-                  >
-                  <span>Add to cart</span>
-                </button>
-              </div>
-            </div>
+                  Resume + Interview Prep (All-in-One)
+                </h3>
 
-            <!-- Card 5 (Online Course) -->
-            <div
-              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="online-courses"
-            >
-              <div>
-                <div class="relative h-[180px] overflow-hidden bg-navy/5">
-                  <img
-                    src="../../img/online-course-1.png"
-                    alt="Resume + Interview Prep"
-                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
-                  />
-                  <!-- Liked heart button -->
+                <div class="relative mb-2.5">
                   <button
                     type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
+                    class="inline-flex items-center gap-1 text-[13px] font-semibold text-gray-400 hover:text-navy transition-colors order-dropdown-btn"
+                    data-target="order-items-1"
                   >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
+                    <span>2 items</span>
+                    <span class="dropdown-text">More</span>
+                    <span
+                      class="material-symbols-outlined text-[16px] transition-transform duration-200 chevron-icon"
+                      >expand_more</span
                     >
                   </button>
-                  <span
-                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
-                    style="background: rgb(54, 166, 247)"
-                  >
-                    Interview
-                  </span>
-                </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >Online courses</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        Resume + Interview Prep (All-in-One)
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
-                  >
-                    This course helps you build transferable skills, craft
-                    strong resumes and personal statements, and prepare for
-                    interviews step by step.
-                  </p>
-                </div>
-              </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
-                >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
-                  >
-                  <span>Add to cart</span>
-                </button>
-              </div>
-            </div>
 
-            <!-- Card 6 (Workshop) -->
-            <div
-              class="pm-card-lift group/workshop bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
-              data-course-card
-              data-category="workshops"
-            >
-              <div>
-                <div
-                  class="relative h-[180px] bg-cover bg-center overflow-hidden"
-                  style="
-                    background-image:
-                      linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.75)),
-                      url('../../img/workshop-1.png');
-                  "
-                >
-                  <!-- Liked heart button -->
-                  <button
-                    type="button"
-                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
-                    aria-label="Remove from wishlist"
-                  >
-                    <span class="material-symbols-outlined text-xl"
-                      >favorite</span
-                    >
-                  </button>
+                  <!-- Expanded order items (hidden by default) -->
                   <div
-                    class="absolute inset-0 p-5 flex flex-col justify-start gap-3 text-white"
+                    id="order-items-1"
+                    class="hidden mt-2 pl-3 border-l border-gray-200 flex flex-col gap-1 text-[13px] text-gray-500"
                   >
-                    <div>
-                      <span
-                        class="inline-flex items-center justify-center text-white text-[9px] font-extrabold px-2.5 h-[18px] bg-white/20 backdrop-blur-sm rounded-full uppercase tracking-wider shadow-sm"
-                      >
-                        Job Search/Career Change
-                      </span>
-                    </div>
-                    <div>
-                      <h4
-                        class="text-sm font-bold font-headline leading-tight mb-2 pr-12 line-clamp-2"
-                      >
-                        Build an English Resume for Career Transitions
-                      </h4>
-                      <div
-                        class="space-y-0.5 opacity-90 text-[10px] font-medium font-body"
-                      >
-                        <p>Date | 2025.05.20</p>
-                        <p>Location | North York centre</p>
-                      </div>
-                    </div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
                   </div>
                 </div>
-                <div class="p-5">
-                  <div class="flex flex-col gap-1 mb-2">
-                    <div class="flex items-center gap-2">
-                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                        >Workshops</span
-                      >
-                      <span class="text-[10px] font-semibold text-gray-400"
-                        >·</span
-                      >
-                      <span class="text-[10px] font-semibold text-gray-400"
-                        >2025.05.10</span
-                      >
-                    </div>
-                    <div class="flex justify-between items-start gap-3">
-                      <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
-                      >
-                        UX Design Fundamentals
-                      </h3>
-                      <span class="text-base font-extrabold text-navy"
-                        >$2800</span
-                      >
-                    </div>
-                  </div>
-                  <p
-                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+
+                <div class="flex items-center gap-2">
+                  <span class="text-[16px] font-bold text-navy font-headline"
+                    >$2800</span
                   >
-                    This course helps you build transferable skills, craft
-                    strong resumes and personal statements, and prepare for
-                    interviews step by step.
-                  </p>
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-emerald-50 text-emerald-700 border border-emerald-100">Paid</span>
                 </div>
               </div>
-              <div
-                class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center"
-              >
-                <button
-                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+
+              <div class="shrink-0 mt-1 md:mt-0 flex md:block justify-start">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center px-6 py-2.5 bg-orange hover:bg-orange-hover text-white text-[13px] font-bold rounded-2xl transition-colors font-headline w-full md:w-auto text-center"
                 >
-                  <span class="material-symbols-outlined text-[18px]"
-                    >shopping_cart</span
+                  View details
+                </a>
+              </div>
+            </div>
+
+            <!-- Order 2 (Expanded by default) -->
+            <div
+              class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-5 border-b border-gray-soft last:border-b-0"
+            >
+              <div class="flex-1 min-w-0">
+                <div
+                  class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-gray-400 mb-1.5 font-medium font-body"
+                >
+                  <span class="whitespace-nowrap">Placed on 0000-00-00</span>
+                  <span class="whitespace-nowrap">Order no. AAA1000002</span>
+                </div>
+                <h3
+                  class="text-[17px] font-bold text-navy font-headline tracking-tight mb-1.5"
+                >
+                  Resume + Interview Prep (All-in-One)
+                </h3>
+
+                <div class="relative mb-2.5">
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 text-[13px] font-semibold text-gray-400 hover:text-navy transition-colors order-dropdown-btn"
+                    data-target="order-items-2"
                   >
-                  <span>Add to cart</span>
-                </button>
+                    <span>2 items</span>
+                    <span class="dropdown-text">Close</span>
+                    <span
+                      class="material-symbols-outlined text-[16px] transition-transform duration-200 chevron-icon rotate-180"
+                      >expand_more</span
+                    >
+                  </button>
+
+                  <!-- Expanded order items (visible by default) -->
+                  <div
+                    id="order-items-2"
+                    class="mt-2 pl-3 border-l border-gray-200 flex flex-col gap-1 text-[13px] text-gray-500"
+                  >
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <span class="text-[16px] font-bold text-navy font-headline"
+                    >$2800</span
+                  >
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-emerald-50 text-emerald-700 border border-emerald-100">Paid</span>
+                </div>
+              </div>
+
+              <div class="shrink-0 mt-1 md:mt-0 flex md:block justify-start">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center px-6 py-2.5 bg-orange hover:bg-orange-hover text-white text-[13px] font-bold rounded-2xl transition-colors font-headline w-full md:w-auto text-center"
+                >
+                  View details
+                </a>
+              </div>
+            </div>
+
+            <!-- Order 3 -->
+            <div
+              class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-5 border-b border-gray-soft last:border-b-0"
+            >
+              <div class="flex-1 min-w-0">
+                <div
+                  class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-gray-400 mb-1.5 font-medium font-body"
+                >
+                  <span class="whitespace-nowrap">Placed on 0000-00-00</span>
+                  <span class="whitespace-nowrap">Order no. AAA1000003</span>
+                </div>
+                <h3
+                  class="text-[17px] font-bold text-navy font-headline tracking-tight mb-1.5"
+                >
+                  Resume + Interview Prep (All-in-One)
+                </h3>
+
+                <div class="relative mb-2.5">
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 text-[13px] font-semibold text-gray-400 hover:text-navy transition-colors order-dropdown-btn"
+                    data-target="order-items-3"
+                  >
+                    <span>2 items</span>
+                    <span class="dropdown-text">More</span>
+                    <span
+                      class="material-symbols-outlined text-[16px] transition-transform duration-200 chevron-icon"
+                      >expand_more</span
+                    >
+                  </button>
+
+                  <!-- Expanded order items (hidden by default) -->
+                  <div
+                    id="order-items-3"
+                    class="hidden mt-2 pl-3 border-l border-gray-200 flex flex-col gap-1 text-[13px] text-gray-500"
+                  >
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <span class="text-[16px] font-bold text-navy font-headline"
+                    >$2800</span
+                  >
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-emerald-50 text-emerald-700 border border-emerald-100">Paid</span>
+                </div>
+              </div>
+
+              <div class="shrink-0 mt-1 md:mt-0 flex md:block justify-start">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center px-6 py-2.5 bg-orange hover:bg-orange-hover text-white text-[13px] font-bold rounded-2xl transition-colors font-headline w-full md:w-auto text-center"
+                >
+                  View details
+                </a>
+              </div>
+            </div>
+
+            <!-- Order 4 (Refund Processing) -->
+            <div
+              class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-5 border-b border-gray-soft last:border-b-0"
+            >
+              <div class="flex-1 min-w-0">
+                <div
+                  class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-gray-400 mb-1.5 font-medium font-body"
+                >
+                  <span class="whitespace-nowrap">Placed on 0000-00-00</span>
+                  <span class="whitespace-nowrap">Order no. AAA1000004</span>
+                </div>
+                <h3
+                  class="text-[17px] font-bold text-navy font-headline tracking-tight mb-1.5"
+                >
+                  Resume + Interview Prep (All-in-One)
+                </h3>
+
+                <div class="relative mb-2.5">
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 text-[13px] font-semibold text-gray-400 hover:text-navy transition-colors order-dropdown-btn"
+                    data-target="order-items-4"
+                  >
+                    <span>2 items</span>
+                    <span class="dropdown-text">More</span>
+                    <span
+                      class="material-symbols-outlined text-[16px] transition-transform duration-200 chevron-icon"
+                      >expand_more</span
+                    >
+                  </button>
+
+                  <!-- Expanded order items (hidden by default) -->
+                  <div
+                    id="order-items-4"
+                    class="hidden mt-2 pl-3 border-l border-gray-200 flex flex-col gap-1 text-[13px] text-gray-500"
+                  >
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <span class="text-[16px] font-bold text-navy font-headline"
+                    >$2800</span
+                  >
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-amber-50 text-amber-700 border border-amber-100">Refund processing</span>
+                </div>
+              </div>
+
+              <div class="shrink-0 mt-1 md:mt-0 flex md:block justify-start">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center px-6 py-2.5 bg-orange hover:bg-orange-hover text-white text-[13px] font-bold rounded-2xl transition-colors font-headline w-full md:w-auto text-center"
+                >
+                  View details
+                </a>
+              </div>
+            </div>
+
+            <!-- Order 5 (Muted/Faded styling only on text details) -->
+            <div
+              class="flex flex-col md:flex-row md:items-center justify-between gap-4 py-5 border-b border-gray-soft last:border-b-0"
+            >
+              <div class="flex-1 min-w-0 opacity-40">
+                <div
+                  class="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] text-gray-400 mb-1.5 font-medium font-body"
+                >
+                  <span class="whitespace-nowrap">Placed on 0000-00-00</span>
+                  <span class="whitespace-nowrap">Order no. AAA1000005</span>
+                </div>
+                <h3
+                  class="text-[17px] font-bold text-navy font-headline tracking-tight mb-1.5"
+                >
+                  Resume + Interview Prep (All-in-One)
+                </h3>
+
+                <div class="relative mb-2.5">
+                  <button
+                    type="button"
+                    class="inline-flex items-center gap-1 text-[13px] font-semibold text-gray-400 hover:text-navy transition-colors order-dropdown-btn"
+                    data-target="order-items-5"
+                    disabled
+                  >
+                    <span>2 items</span>
+                    <span class="dropdown-text">More</span>
+                    <span
+                      class="material-symbols-outlined text-[16px] transition-transform duration-200 chevron-icon"
+                      >expand_more</span
+                    >
+                  </button>
+
+                  <!-- Expanded order items (hidden by default) -->
+                  <div
+                    id="order-items-5"
+                    class="hidden mt-2 pl-3 border-l border-gray-200 flex flex-col gap-1 text-[13px] text-gray-500"
+                  >
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                    <div>Resume + Interview Prep (All-in-One)</div>
+                  </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                  <span class="text-[16px] font-bold text-navy font-headline"
+                    >$2800</span
+                  >
+                  <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-bold bg-red-50 text-red-700 border border-red-100">Refunded</span>
+                </div>
+              </div>
+
+              <div class="shrink-0 mt-1 md:mt-0 flex md:block justify-start">
+                <a
+                  href="#"
+                  class="inline-flex items-center justify-center px-6 py-2.5 bg-orange hover:bg-orange-hover text-white text-[13px] font-bold rounded-2xl transition-colors font-headline w-full md:w-auto text-center"
+                >
+                  View details
+                </a>
               </div>
             </div>
           </div>
         </section>
       </div>
     </main>
-
     <!-- Footer -->
     <footer
       class="bg-white border-t border-[#eaecf0] pt-[80px] pb-[60px] mt-auto"
@@ -1758,52 +1555,23 @@
         });
       })();
 
-      (function wishlistFilters() {
-        var filterButtons = Array.prototype.slice.call(
-          document.querySelectorAll('.course-filter-button')
-        );
-        var cards = Array.prototype.slice.call(
-          document.querySelectorAll('[data-course-card]')
-        );
+      (function orderHistoryDropdown() {
+        var dropdownBtns = document.querySelectorAll('.order-dropdown-btn');
+        dropdownBtns.forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var targetId = btn.getAttribute('data-target');
+            var target = document.getElementById(targetId);
+            var textSpan = btn.querySelector('.dropdown-text');
+            var iconSpan = btn.querySelector('.chevron-icon');
 
-        filterButtons.forEach(function (button) {
-          button.addEventListener('click', function () {
-            var filterValue = button.getAttribute('data-filter') || 'all';
-
-            filterButtons.forEach(function (btn) {
-              var isActive = btn === button;
-              btn.classList.toggle('is-active', isActive);
-              btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-            });
-
-            cards.forEach(function (card) {
-              if (
-                filterValue === 'all' ||
-                card.getAttribute('data-category') === filterValue
-              ) {
-                card.style.display = '';
-              } else {
-                card.style.display = 'none';
-              }
-            });
-          });
-        });
-
-        // Add wishlist heart toggle interaction
-        var heartButtons = document.querySelectorAll('.favorite-heart');
-        heartButtons.forEach(function (heart) {
-          heart.addEventListener('click', function (e) {
-            e.stopPropagation();
-            heart.classList.toggle('favorite-heart--liked');
-            var card = heart.closest('[data-course-card]');
-            if (!heart.classList.contains('favorite-heart--liked')) {
-              if (card) {
-                card.style.opacity = '0.5';
-              }
+            if (target.classList.contains('hidden')) {
+              target.classList.remove('hidden');
+              textSpan.textContent = 'Close';
+              iconSpan.classList.add('rotate-180');
             } else {
-              if (card) {
-                card.style.opacity = '1';
-              }
+              target.classList.add('hidden');
+              textSpan.textContent = 'More';
+              iconSpan.classList.remove('rotate-180');
             }
           });
         });

--- a/public/html/mypage/wishlist.html
+++ b/public/html/mypage/wishlist.html
@@ -1,0 +1,1801 @@
+<!doctype html>
+<html
+  class="light"
+  lang="en"
+  style="--font-heading: 'Poppins', ui-sans-serif, system-ui, sans-serif"
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pacemaker | My Wishlist</title>
+
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700;800&family=Source+Sans+3:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+
+    <script id="tailwind-config">
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            colors: {
+              navy: '#00263b',
+              teal: '#00adbd',
+              orange: '#ff4f02',
+              'orange-hover': '#e04400',
+              'gray-soft': '#f2f4f7',
+              'surface-container-low': '#f2f4f7',
+              surface: '#f7f9fc',
+              body: '#475467'
+            },
+            fontFamily: {
+              headline: ['Poppins', 'sans-serif'],
+              body: ['Source Sans 3', 'sans-serif'],
+              label: ['Poppins', 'sans-serif']
+            },
+            boxShadow: {
+              card: '0 10px 30px rgba(0,38,59,0.08)'
+            },
+            borderRadius: {
+              DEFAULT: '0.125rem',
+              lg: '0.25rem',
+              xl: '0.5rem',
+              '2xl': '16px',
+              full: '9999px'
+            }
+          }
+        }
+      };
+    </script>
+
+    <style>
+      html {
+        scrollbar-gutter: stable;
+      }
+
+      body {
+        max-width: 1920px;
+        margin: 0 auto;
+        background-color: #f7f9fc;
+        font-family: 'Source Sans 3', sans-serif;
+        color: #475467;
+      }
+
+      nav {
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: #ffffff;
+        border-bottom: 1px solid #f2f4f6;
+        padding: 12px 0;
+      }
+
+      .nav-inner,
+      .page-container {
+        max-width: 1248px;
+        margin-left: auto;
+        margin-right: auto;
+        padding-left: 24px;
+        padding-right: 24px;
+        box-sizing: border-box;
+      }
+
+      .nav-inner {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .nav-logo img {
+        height: 32px;
+        width: auto;
+        display: block;
+      }
+
+      .nav-center {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .nav-item {
+        position: relative;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        font-family: 'Poppins', sans-serif;
+        font-size: 0.925rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        color: #6b7280;
+        cursor: pointer;
+        transition: all 0.2s;
+        border: none;
+        background: none;
+        text-decoration: none;
+      }
+
+      .nav-item:hover {
+        background: #f3f4f6;
+        color: #00263b;
+      }
+
+      .nav-right {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+
+      .btn-auth {
+        font-family: 'Poppins', sans-serif;
+        font-size: 0.85rem;
+        font-weight: 700;
+        padding: 8px 16px;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.2s;
+        text-decoration: none;
+      }
+
+      .btn-login {
+        color: #00263b;
+      }
+
+      .btn-login:hover {
+        background: #f3f4f6;
+      }
+
+      .btn-signup {
+        background: #00263b;
+        color: #fff;
+      }
+
+      .btn-signup:hover {
+        background: #001e2f;
+      }
+
+      .nav-mobile-top {
+        display: none;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .nav-hamburger {
+        width: 40px;
+        height: 40px;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        background: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+      }
+
+      .mobile-nav-panel {
+        display: none;
+      }
+
+      .mobile-nav-accordion-panel {
+        display: grid;
+        grid-template-rows: 0fr;
+        opacity: 0;
+        transition:
+          grid-template-rows 0.3s ease-out,
+          opacity 0.3s ease-out;
+      }
+      .mobile-nav-accordion-panel.is-open {
+        grid-template-rows: 1fr;
+        opacity: 1;
+      }
+      .mobile-nav-accordion-chevron {
+        transition: transform 0.3s ease;
+      }
+      .mobile-nav-accordion-toggle[aria-expanded='true']
+        .mobile-nav-accordion-chevron {
+        transform: rotate(180deg);
+      }
+
+      @media (max-width: 768px) {
+        .nav-inner {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+        }
+        .nav-center,
+        .nav-right,
+        .nav-desktop {
+          display: none;
+        }
+
+        .nav-mobile-top {
+          display: flex;
+          width: 100%;
+        }
+
+        .nav-logo {
+          display: none;
+        }
+
+        .mobile-nav-panel {
+          display: block;
+          width: 100%;
+          flex-basis: 100%;
+          overflow: hidden;
+          max-height: 0;
+          opacity: 0;
+          padding-top: 0;
+          pointer-events: none;
+          transition:
+            max-height 0.3s ease-out,
+            opacity 0.25s ease-out,
+            padding-top 0.25s ease-out;
+        }
+
+        .mobile-nav-panel.is-open {
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
+          opacity: 1;
+          padding-top: 12px;
+          pointer-events: auto;
+        }
+
+        .nav-hamburger [data-menu-close] {
+          display: none;
+        }
+
+        .nav-hamburger.is-open [data-menu-open] {
+          display: none;
+        }
+
+        .nav-hamburger.is-open [data-menu-close] {
+          display: block;
+        }
+      }
+
+      /* Course Filter Button Style */
+      .course-filter-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: auto;
+        height: 32px;
+        padding: 0 1rem;
+        border: 1px solid #d0d5dd;
+        border-radius: 12px;
+        background: #ffffff;
+        color: #667085;
+        font-family: 'Poppins', sans-serif;
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 1;
+        white-space: nowrap;
+        flex-shrink: 0;
+        cursor: pointer;
+        transition:
+          border-color 0.3s ease,
+          color 0.3s ease,
+          background-color 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+
+      @media (min-width: 768px) {
+        .course-filter-button {
+          min-width: 110px;
+          height: 40px;
+          padding: 0 1.5rem;
+          border-radius: 16px;
+          font-size: 14px;
+        }
+      }
+
+      .course-filter-button:hover {
+        border-color: #ff4f02;
+        color: #ff4f02;
+        background-color: rgba(255, 79, 2, 0.05);
+      }
+
+      .course-filter-button.is-active {
+        border-color: #ff4f02;
+        color: #ff4f02;
+        background-color: rgba(255, 79, 2, 0.08);
+        box-shadow: 0 10px 25px -5px rgba(255, 79, 2, 0.12);
+        font-weight: 700;
+      }
+
+      .card-shadow {
+        box-shadow: 0 10px 30px rgba(0, 38, 59, 0.08);
+      }
+
+      .pm-card-lift {
+        transition:
+          transform 0.3s ease,
+          box-shadow 0.3s ease;
+      }
+
+      .pm-card-lift:hover {
+        transform: translateY(-8px);
+        box-shadow: 0 20px 40px rgba(0, 38, 59, 0.12);
+      }
+
+      /* Save: outline heart → filled on hover */
+      .favorite-heart .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 0,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        color: #9ca3af;
+        transition:
+          color 0.3s ease,
+          font-variation-settings 0.45s cubic-bezier(0.33, 1, 0.53, 1);
+      }
+      @media (hover: hover) {
+        .favorite-heart:hover .material-symbols-outlined {
+          font-variation-settings:
+            'FILL' 1,
+            'wght' 400,
+            'GRAD' 0,
+            'opsz' 24;
+          color: #ff4f02;
+        }
+        .favorite-heart--liked:hover .material-symbols-outlined {
+          color: #e04400;
+        }
+      }
+      .favorite-heart--liked .material-symbols-outlined {
+        font-variation-settings:
+          'FILL' 1,
+          'wght' 400,
+          'GRAD' 0,
+          'opsz' 24;
+        color: #ff4f02;
+      }
+      a:focus-visible,
+      button:focus-visible {
+        outline: 2px solid #00adbd;
+        outline-offset: 2px;
+      }
+    </style>
+  </head>
+
+  <body
+    class="bg-surface font-body text-body antialiased min-h-screen flex flex-col"
+  >
+    <!-- Skip Link for Accessibility -->
+    <a
+      href="#main-content"
+      class="fixed left-4 top-4 z-[9999] -translate-y-[200%] rounded-2xl bg-navy px-4 py-3 text-sm font-bold text-white focus:translate-y-0 focus:outline-none focus:ring-2 focus:ring-teal"
+      >Skip to content</a
+    >
+
+    <!-- 1. NAVBAR -->
+    <nav>
+      <div class="nav-inner">
+        <!-- Desktop Logo -->
+        <a aria-label="Pacemaker home" class="nav-logo" href="../main.html">
+          <img
+            alt="Pacemaker Logo"
+            src="../../img/logo.webp"
+            style="height: 32px; width: auto; display: block"
+            onerror="this.src = '../../icons/paceup-logo-black.svg'"
+          />
+        </a>
+        <!-- Navigation Menu & Auth (Unified spacing) -->
+        <div class="nav-desktop flex items-center ml-auto">
+          <div class="nav-center">
+            <a class="nav-item" href="../workshops/workshop_list.html"
+              >Workshops</a
+            >
+            <a class="nav-item" href="../courses/course_list.html"
+              >Online Courses</a
+            >
+            <a class="nav-item" href="../ebooks/ebook_list.html">E-books</a>
+
+            <!-- Cart Button -->
+            <a href="cart.html" class="nav-item">
+              <span
+                class="flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[11px] font-extrabold shadow-sm"
+                >3</span
+              >
+              <span>Cart</span>
+            </a>
+
+            <!-- User Profile Dropdown -->
+            <div class="relative group" id="user-profile-menu">
+              <button
+                type="button"
+                id="user-profile-toggle"
+                class="nav-item focus:outline-none"
+                aria-expanded="false"
+              >
+                <span class="material-symbols-outlined text-[20px]"
+                  >account_circle</span
+                >
+                <span>Jamie</span>
+                <span
+                  class="material-symbols-outlined text-sm transition-transform group-hover:rotate-180"
+                  >expand_more</span
+                >
+              </button>
+
+              <!-- Dropdown Menu (Centered relative to Jamie button) -->
+              <div
+                id="user-profile-dropdown"
+                class="absolute left-1/2 -translate-x-1/2 top-full mt-2 w-48 rounded-2xl bg-white p-2 shadow-2xl border border-gray-100 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 z-50"
+              >
+                <a
+                  href="mypage.html"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >space_dashboard</span
+                  >
+                  <span>My Page</span>
+                </a>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >receipt_long</span
+                  >
+                  <span>Order History</span>
+                </a>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-gray-700 hover:bg-gray-50 hover:text-navy transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg"
+                    >settings</span
+                  >
+                  <span>Settings</span>
+                </a>
+                <div class="my-1 border-t border-gray-100"></div>
+                <a
+                  href="#"
+                  class="flex items-center gap-2 px-3 py-2.5 rounded-xl text-sm font-semibold text-red-500 hover:bg-red-50 transition-colors"
+                >
+                  <span class="material-symbols-outlined text-lg">logout</span>
+                  <span>Log Out</span>
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Mobile Navigation Header (Inside nav-inner) -->
+        <div class="nav-mobile-top">
+          <a href="../main.html" class="flex-shrink-0" style="display: block">
+            <img
+              alt="Pacemaker Logo"
+              src="../../img/logo.webp"
+              style="height: 28px; width: auto; max-width: none; display: block"
+              onerror="this.src = '../../icons/paceup-logo-black.svg'"
+            />
+          </a>
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <button
+              aria-controls="mobile-nav-menu"
+              aria-expanded="false"
+              aria-label="Open menu"
+              class="nav-hamburger"
+              id="mobile-nav-toggle"
+              type="button"
+            >
+              <svg
+                data-menu-open
+                fill="none"
+                height="18"
+                stroke="#00263b"
+                stroke-linecap="round"
+                stroke-width="2.5"
+                viewBox="0 0 24 24"
+                width="18"
+              >
+                <line x1="3" x2="21" y1="6" y2="6"></line>
+                <line x1="3" x2="21" y1="12" y2="12"></line>
+                <line x1="3" x2="21" y1="18" y2="18"></line>
+              </svg>
+              <svg
+                data-menu-close
+                fill="none"
+                height="18"
+                stroke="#00263b"
+                stroke-linecap="round"
+                stroke-width="2.5"
+                viewBox="0 0 24 24"
+                width="18"
+              >
+                <line x1="6" x2="18" y1="6" y2="18"></line>
+                <line x1="18" x2="6" y1="6" y2="18"></line>
+              </svg>
+            </button>
+          </div>
+        </div>
+        <!-- Mobile Dropdown Panel -->
+        <div class="mobile-nav-panel" id="mobile-nav-menu">
+          <div class="rounded-none border border-gray-200 bg-white p-3">
+            <div class="border-t border-gray-100 pt-2">
+              <div class="py-1">
+                <a
+                  class="flex items-center h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                  href="../main.html"
+                  ><span>HOME</span></a
+                >
+              </div>
+              <div class="py-1">
+                <button
+                  type="button"
+                  aria-expanded="false"
+                  class="mobile-nav-accordion-toggle flex w-full items-center justify-between h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                  data-target="mobile-nav-programs"
+                >
+                  <span>PROGRAMS</span>
+                  <svg
+                    class="mobile-nav-accordion-chevron w-4 h-4"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="m6 9 6 6 6-6"></path>
+                  </svg>
+                </button>
+                <div
+                  class="mobile-nav-accordion-panel"
+                  id="mobile-nav-programs"
+                >
+                  <div class="overflow-hidden">
+                    <div class="flex flex-col gap-1">
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="../workshops/workshop_list.html"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >calendar_month</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >Workshops</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Live sessions, practical events, and real-world
+                            feedback.
+                          </p>
+                        </div>
+                      </a>
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="../courses/course_list.html"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >play_lesson</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >Online Courses</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Guided lessons to help with resumes, interviews, and
+                            career moves.
+                          </p>
+                        </div>
+                      </a>
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="../ebooks/ebook_list.html"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >menu_book</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >E-books</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Quick reads with practical tips for searching and
+                            applying with confidence.
+                          </p>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="py-1">
+                <button
+                  type="button"
+                  aria-expanded="false"
+                  class="mobile-nav-accordion-toggle flex w-full items-center justify-between h-11 rounded-lg px-1 text-sm font-semibold leading-none tracking-wide text-gray-700 transition-colors hover:text-navy"
+                  data-target="mobile-nav-user-profile"
+                >
+                  <span class="flex items-center gap-2">
+                    <span class="material-symbols-outlined text-[20px]"
+                      >account_circle</span
+                    >
+                    <span>JAMIE</span>
+                  </span>
+                  <svg
+                    class="mobile-nav-accordion-chevron w-4 h-4"
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                  >
+                    <path d="m6 9 6 6 6-6"></path>
+                  </svg>
+                </button>
+                <div
+                  class="mobile-nav-accordion-panel"
+                  id="mobile-nav-user-profile"
+                >
+                  <div class="overflow-hidden">
+                    <div class="flex flex-col gap-1">
+                      <!-- Cart -->
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="cart.html"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100 relative"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >shopping_cart</span
+                          >
+                          <span
+                            class="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-orange text-white text-[10px] font-extrabold shadow-sm"
+                            >3</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >Cart</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Check your selected courses and books.
+                          </p>
+                        </div>
+                      </a>
+                      <!-- My Page -->
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="mypage.html"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >space_dashboard</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >My Page</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            View your statistics, courses, and settings.
+                          </p>
+                        </div>
+                      </a>
+                      <!-- Order History -->
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="#"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >receipt_long</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >Order History</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Manage your purchases and receipt details.
+                          </p>
+                        </div>
+                      </a>
+                      <!-- Settings -->
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-navy/5"
+                        href="#"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-gray-50 text-gray-400 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-navy group-hover/item:border-gray-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >settings</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-navy mb-0.5"
+                              >Settings</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-gray-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-gray-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Configure account preferences and security.
+                          </p>
+                        </div>
+                      </a>
+                      <!-- Log Out -->
+                      <a
+                        class="group/item flex items-start gap-4 p-3 rounded-xl transition-all hover:bg-red-50"
+                        href="#"
+                      >
+                        <div
+                          class="mt-0.5 p-2 rounded-lg bg-red-50 text-red-500 transition-colors shadow-sm border border-transparent group-hover/item:bg-white group-hover/item:text-red-600 group-hover/item:border-red-100"
+                        >
+                          <span class="material-symbols-outlined text-[20px]"
+                            >logout</span
+                          >
+                        </div>
+                        <div class="flex-1">
+                          <div class="flex items-center justify-between">
+                            <span
+                              class="text-[0.95rem] font-bold text-red-500 mb-0.5"
+                              >Log Out</span
+                            >
+                            <span
+                              class="material-symbols-outlined text-[18px] text-red-300 opacity-0 -translate-x-2 transition-all group-hover/item:opacity-100 group-hover/item:translate-x-0"
+                              >chevron_right</span
+                            >
+                          </div>
+                          <p
+                            class="text-[0.825rem] text-red-400 font-medium leading-snug line-clamp-2"
+                          >
+                            Safely sign out of your account.
+                          </p>
+                        </div>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- Main Content Container -->
+    <main
+      id="main-content"
+      class="flex-1 max-w-[1248px] w-full mx-auto px-6 py-12"
+    >
+      <div class="flex flex-col lg:flex-row gap-8">
+        <!-- Left Sidebar -->
+        <aside class="w-full lg:w-[320px] shrink-0">
+          <div
+            class="bg-white rounded-none border border-gray-100 p-6 flex flex-col items-center shadow-card relative sticky top-28"
+          >
+            <!-- Settings Gear Button -->
+            <button
+              class="absolute top-4 right-4 p-2.5 text-body hover:text-orange rounded-2xl hover:bg-orange/10 transition-colors"
+              aria-label="Settings"
+              title="Settings"
+            >
+              <span class="material-symbols-outlined text-xl">settings</span>
+            </button>
+
+            <!-- Profile Avatar -->
+            <div
+              class="w-28 h-28 rounded-full border-4 border-orange/10 p-1 mb-4 shadow-sm relative"
+            >
+              <img
+                src="../../img/user3.png"
+                alt="Jamie"
+                class="w-full h-full object-cover rounded-full"
+                onerror="
+                  this.src =
+                    'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=200&auto=format&fit=crop&q=80'
+                "
+              />
+            </div>
+
+            <!-- Profile Name -->
+            <h2 class="text-xl font-bold text-navy font-headline mb-6">
+              Jamie
+            </h2>
+
+            <!-- Navigation Links -->
+            <nav
+              class="w-full flex flex-col gap-1 border-t border-gray-100 pt-4 !static !p-0 !border-none"
+            >
+              <!-- Inactive Item: My Account -->
+              <a
+                href="./mypage.html"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl">person</span>
+                <span>My Account</span>
+              </a>
+
+              <!-- Inactive Item: Cart -->
+              <a
+                href="cart.html"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >shopping_cart</span
+                >
+                <span>Cart</span>
+              </a>
+
+              <!-- Active Item: Wish list -->
+              <a
+                href="./wishlist.html"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-bold text-orange bg-orange/10 border-l-4 border-orange font-headline transition-all"
+              >
+                <span class="material-symbols-outlined text-xl">favorite</span>
+                <span>Wish list</span>
+              </a>
+
+              <!-- Inactive Item: Order History -->
+              <a
+                href="#"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >receipt_long</span
+                >
+                <span>Order History</span>
+              </a>
+
+              <!-- Inactive Item: Contact Us -->
+              <a
+                href="#"
+                class="flex items-center gap-3 px-4 py-3.5 rounded-none font-medium text-body hover:bg-gray-soft hover:text-navy transition-colors"
+              >
+                <span class="material-symbols-outlined text-xl"
+                  >support_agent</span
+                >
+                <span>Contact Us</span>
+              </a>
+            </nav>
+          </div>
+        </aside>
+
+        <!-- Right Main Content: My Wishlist -->
+        <section class="flex-1 min-w-0">
+          <div class="mb-6">
+            <h1
+              class="text-[1.85rem] font-bold text-navy font-headline tracking-tight mb-6"
+            >
+              My Wishlist
+            </h1>
+
+            <!-- Category Filter Tabs -->
+            <div class="flex flex-wrap gap-3 mb-8">
+              <button
+                class="course-filter-button is-active"
+                type="button"
+                aria-pressed="true"
+                data-filter="all"
+              >
+                All
+              </button>
+              <button
+                class="course-filter-button"
+                type="button"
+                aria-pressed="false"
+                data-filter="online-courses"
+              >
+                Online courses
+              </button>
+              <button
+                class="course-filter-button"
+                type="button"
+                aria-pressed="false"
+                data-filter="e-books"
+              >
+                E-books
+              </button>
+              <button
+                class="course-filter-button"
+                type="button"
+                aria-pressed="false"
+                data-filter="workshops"
+              >
+                Workshops
+              </button>
+            </div>
+          </div>
+
+          <!-- Wishlist Grid -->
+          <div
+            id="wishlistGrid"
+            class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+          >
+            <!-- Card 1 (Online Course) -->
+            <div
+              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="online-courses"
+            >
+              <div>
+                <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                  <img
+                    src="../../img/online-course-1.png"
+                    alt="Resume + Interview Prep"
+                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                  />
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <span
+                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                    style="background: rgb(54, 166, 247)"
+                  >
+                    interview
+                  </span>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    This course helps you build transferable skills, craft
+                    strong resumes and personal statements, and prepare for
+                    interviews step by step.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Card 2 (Online Course) -->
+            <div
+              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="online-courses"
+            >
+              <div>
+                <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                  <img
+                    src="../../img/online-course-1.png"
+                    alt="Resume + Interview Prep"
+                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                  />
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <span
+                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                    style="background: rgb(54, 166, 247)"
+                  >
+                    Interview
+                  </span>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    This course helps you build transferable skills, craft
+                    strong resumes and personal statements, and prepare for
+                    interviews step by step.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Card 3 (Online Course) -->
+            <div
+              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="online-courses"
+            >
+              <div>
+                <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                  <img
+                    src="../../img/online-course-2.png"
+                    alt="Resume + Interview Prep"
+                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                  />
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <span
+                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                    style="background: rgb(245, 158, 11)"
+                  >
+                    Networking
+                  </span>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    This course helps you build transferable skills, craft
+                    strong resumes and personal statements, and prepare for
+                    interviews step by step.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Card 4 (E-book) -->
+            <div
+              class="pm-card-lift group/ebook bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="e-books"
+            >
+              <div>
+                <div
+                  class="relative h-[180px] bg-[#FFF5F2] p-6 flex flex-col justify-start"
+                >
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <span
+                    class="mb-3 inline-flex w-fit items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                    style="background: rgb(255, 126, 84)"
+                  >
+                    Marketing
+                  </span>
+                  <div>
+                    <h4
+                      class="text-[#FF6B3D] text-xl font-extrabold font-headline leading-tight mb-1"
+                    >
+                      Marketing
+                    </h4>
+                    <p
+                      class="text-[#FF6B3D] text-[11px] font-medium leading-normal line-clamp-3 pr-6"
+                    >
+                      The 94% Success Formula: A Proven Approach to Job & Career
+                      Transitions
+                    </p>
+                  </div>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >E-books</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        Branding & Networking for Marketers
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    Learn what truly matters in hiring criteria and how to build
+                    the right experience to strengthen your resume.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Card 5 (Online Course) -->
+            <div
+              class="pm-card-lift group/course bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="online-courses"
+            >
+              <div>
+                <div class="relative h-[180px] overflow-hidden bg-navy/5">
+                  <img
+                    src="../../img/online-course-1.png"
+                    alt="Resume + Interview Prep"
+                    class="w-full h-full object-cover transition-transform duration-500 group-hover/course:scale-105"
+                  />
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <span
+                    class="absolute top-6 left-6 z-10 inline-flex items-center justify-center text-white text-[10px] font-bold px-3 h-[22px] rounded-full uppercase tracking-wider shadow-sm"
+                    style="background: rgb(54, 166, 247)"
+                  >
+                    Interview
+                  </span>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Online courses</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        Resume + Interview Prep (All-in-One)
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    This course helps you build transferable skills, craft
+                    strong resumes and personal statements, and prepare for
+                    interviews step by step.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Card 6 (Workshop) -->
+            <div
+              class="pm-card-lift group/workshop bg-white border border-gray-100 shadow-card overflow-hidden rounded-none flex flex-col justify-between"
+              data-course-card
+              data-category="workshops"
+            >
+              <div>
+                <div
+                  class="relative h-[180px] bg-cover bg-center overflow-hidden"
+                  style="
+                    background-image:
+                      linear-gradient(rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.75)),
+                      url('../../img/workshop-1.png');
+                  "
+                >
+                  <!-- Liked heart button -->
+                  <button
+                    type="button"
+                    class="favorite-heart favorite-heart--liked absolute top-4 right-4 z-10 flex h-9 w-9 items-center justify-center rounded-full bg-white shadow-md transition-transform duration-500 ease-out hover:scale-110"
+                    aria-label="Remove from wishlist"
+                  >
+                    <span class="material-symbols-outlined text-xl"
+                      >favorite</span
+                    >
+                  </button>
+                  <div
+                    class="absolute inset-0 p-5 flex flex-col justify-between text-white"
+                  >
+                    <div>
+                      <span
+                        class="inline-flex items-center justify-center text-white text-[9px] font-extrabold px-2.5 h-[18px] bg-white/20 backdrop-blur-sm rounded-full uppercase tracking-wider shadow-sm"
+                      >
+                        Job Search/Career Change
+                      </span>
+                    </div>
+                    <div>
+                      <h4
+                        class="text-sm font-bold font-headline leading-tight mb-2 pr-12 line-clamp-2"
+                      >
+                        Build an English Resume for Career Transitions
+                      </h4>
+                      <div
+                        class="space-y-0.5 opacity-90 text-[10px] font-medium font-body"
+                      >
+                        <p>Date | 2025.05.20</p>
+                        <p>Location | North York centre</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="p-5">
+                  <div class="flex justify-between items-start gap-3 mb-2">
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-2">
+                        <span class="text-[10px] font-semibold text-gray-400"
+                          >2025.05.10</span
+                        >
+                        <span class="text-[10px] font-semibold text-gray-400"
+                          >·</span
+                        >
+                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                          >Workshops</span
+                        >
+                      </div>
+                      <h3
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                      >
+                        UX Design Fundamentals
+                      </h3>
+                    </div>
+                    <span class="text-base font-extrabold text-navy"
+                      >$2800</span
+                    >
+                  </div>
+                  <p
+                    class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
+                  >
+                    This course helps you build transferable skills, craft
+                    strong resumes and personal statements, and prepare for
+                    interviews step by step.
+                  </p>
+                </div>
+              </div>
+              <div class="border-t border-gray-100 px-5 py-4 mt-auto flex justify-center">
+                <button
+                  class="flex items-center gap-2 text-xs font-bold text-orange hover:text-orange-hover transition-colors font-headline"
+                >
+                  <span class="material-symbols-outlined text-[18px]"
+                    >shopping_cart</span
+                  >
+                  <span>Add to cart</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <!-- Footer -->
+    <footer
+      class="bg-white border-t border-[#eaecf0] pt-[80px] pb-[60px] mt-auto"
+    >
+      <div class="page-container">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-10 mb-10">
+          <!-- Left: Logo + Social -->
+          <div>
+            <div class="mb-7">
+              <img
+                src="../../img/logo.webp"
+                alt="Pacemaker Logo"
+                class="h-8 w-auto block"
+                onerror="this.src = '../../icons/paceup-logo-black.svg'"
+              />
+            </div>
+            <p
+              class="text-[0.85rem] font-bold uppercase tracking-[0.16em] text-[#98a2b3] mb-4"
+            >
+              Social
+            </p>
+            <div class="flex gap-3 flex-wrap">
+              <a
+                href="https://www.instagram.com/pacemaker_career"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="Instagram"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+                  <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+                  <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+                </svg>
+              </a>
+              <a
+                href="https://www.facebook.com/globalpacemaker"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="Facebook"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"
+                  />
+                </svg>
+              </a>
+              <a
+                href="https://www.youtube.com/channel/UCyc055VyNuwAMF27dd74smA"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center text-[#344054] no-underline transition-all hover:border-navy hover:text-navy"
+                aria-label="YouTube"
+              >
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46a2.78 2.78 0 0 0-1.95 1.96A29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58A2.78 2.78 0 0 0 3.41 19.54C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z"
+                  />
+                  <polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" />
+                </svg>
+              </a>
+              <a
+                href="https://www.threads.com/@pacemaker_career"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="w-11 h-11 rounded-full border border-[#d0d5dd] inline-flex items-center justify-center no-underline transition-all hover:border-navy hover:text-navy"
+                style="
+                  font-family: 'Poppins', sans-serif;
+                  font-weight: 800;
+                  font-size: 0.85rem;
+                  color: #344054;
+                "
+                aria-label="Threads"
+              >
+                @
+              </a>
+            </div>
+          </div>
+
+          <!-- Right: Contact -->
+          <div class="w-full md:ml-auto md:w-fit md:text-right">
+            <p
+              class="text-[0.85rem] font-bold uppercase tracking-[0.16em] text-[#98a2b3] mb-4 md:text-right"
+            >
+              Contact
+            </p>
+            <ul class="list-none flex flex-col gap-3 md:items-end p-0 m-0">
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path
+                    d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"
+                  />
+                  <polyline points="22,6 12,13 2,6" />
+                </svg>
+                <a
+                  href="mailto:Hello@pacemakerca.com"
+                  class="text-[#344054] no-underline hover:text-navy transition-colors"
+                  >Hello@pacemakerca.com</a
+                >
+              </li>
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path
+                    d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.61 3.44 2 2 0 0 1 3.6 1.27h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 8.96a16 16 0 0 0 6.13 6.13l.96-.96a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
+                  />
+                </svg>
+                <a
+                  href="tel:+16476120523"
+                  class="text-[#344054] no-underline hover:text-navy transition-colors"
+                  >+1 647-612-0523</a
+                >
+              </li>
+              <li
+                class="flex items-center gap-2 text-[0.9rem] text-[#344054] md:justify-end"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="#667085"
+                  stroke-width="1.8"
+                  stroke-linecap="round"
+                  class="flex-shrink-0"
+                >
+                  <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                <span>Toronto, ON, Canada</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+        <p class="text-[0.9rem] text-[#98a2b3] mt-8 md:mt-0">
+          © 2026 Pacemaker. All rights reserved.
+        </p>
+      </div>
+    </footer>
+
+    <!-- Mobile Nav & Filter Scripts -->
+    <script>
+      (function mobileNav() {
+        var menuToggle = document.getElementById('mobile-nav-toggle');
+        var menu = document.getElementById('mobile-nav-menu');
+        if (!menuToggle || !menu) return;
+
+        function setMenuOpen(isOpen) {
+          menu.classList.toggle('is-open', isOpen);
+          menuToggle.classList.toggle('is-open', isOpen);
+          menuToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+          menuToggle.setAttribute(
+            'aria-label',
+            isOpen ? 'Close menu' : 'Open menu'
+          );
+        }
+
+        menuToggle.addEventListener('click', function () {
+          setMenuOpen(!menu.classList.contains('is-open'));
+        });
+
+        document.addEventListener('click', function (event) {
+          if (!menu.classList.contains('is-open')) return;
+          if (menu.contains(event.target) || menuToggle.contains(event.target))
+            return;
+          setMenuOpen(false);
+        });
+
+        document.addEventListener('keydown', function (event) {
+          if (event.key === 'Escape') {
+            setMenuOpen(false);
+          }
+        });
+
+        window.addEventListener('resize', function () {
+          if (window.innerWidth > 768) {
+            setMenuOpen(false);
+          }
+        });
+
+        Array.prototype.forEach.call(
+          document.querySelectorAll('.mobile-nav-accordion-toggle'),
+          function (toggle) {
+            var panelId = toggle.getAttribute('data-target');
+            var panel = panelId ? document.getElementById(panelId) : null;
+            if (!panel) return;
+
+            toggle.addEventListener('click', function () {
+              var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId =
+                        otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId
+                        ? document.getElementById(otherPanelId)
+                        : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
+              toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+              panel.classList.toggle('is-open', !isOpen);
+            });
+          }
+        );
+      })();
+
+      (function userProfileDropdown() {
+        var toggle = document.getElementById('user-profile-toggle');
+        var dropdown = document.getElementById('user-profile-dropdown');
+        var menu = document.getElementById('user-profile-menu');
+        if (!toggle || !dropdown || !menu) return;
+
+        toggle.addEventListener('click', function (e) {
+          e.stopPropagation();
+          var isOpen = dropdown.classList.contains('!opacity-100');
+          if (isOpen) {
+            dropdown.classList.remove('!opacity-100', '!visible');
+          } else {
+            dropdown.classList.add('!opacity-100', '!visible');
+          }
+        });
+
+        document.addEventListener('click', function (e) {
+          if (!menu.contains(e.target)) {
+            dropdown.classList.remove('!opacity-100', '!visible');
+          }
+        });
+      })();
+
+      (function wishlistFilters() {
+        var filterButtons = Array.prototype.slice.call(
+          document.querySelectorAll('.course-filter-button')
+        );
+        var cards = Array.prototype.slice.call(
+          document.querySelectorAll('[data-course-card]')
+        );
+
+        filterButtons.forEach(function (button) {
+          button.addEventListener('click', function () {
+            var filterValue = button.getAttribute('data-filter') || 'all';
+
+            filterButtons.forEach(function (btn) {
+              var isActive = btn === button;
+              btn.classList.toggle('is-active', isActive);
+              btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+            });
+
+            cards.forEach(function (card) {
+              if (
+                filterValue === 'all' ||
+                card.getAttribute('data-category') === filterValue
+              ) {
+                card.style.display = '';
+              } else {
+                card.style.display = 'none';
+              }
+            });
+          });
+        });
+
+        // Add wishlist heart toggle interaction
+        var heartButtons = document.querySelectorAll('.favorite-heart');
+        heartButtons.forEach(function (heart) {
+          heart.addEventListener('click', function (e) {
+            e.stopPropagation();
+            heart.classList.toggle('favorite-heart--liked');
+            var card = heart.closest('[data-course-card]');
+            if (!heart.classList.contains('favorite-heart--liked')) {
+              if (card) {
+                card.style.opacity = '0.5';
+              }
+            } else {
+              if (card) {
+                card.style.opacity = '1';
+              }
+            }
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/public/html/mypage/wishlist.html
+++ b/public/html/mypage/wishlist.html
@@ -1038,22 +1038,22 @@
                   </span>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >Online courses</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >Online courses</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         Resume + Interview Prep (All-in-One)
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1107,22 +1107,22 @@
                   </span>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >Online courses</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >Online courses</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         Resume + Interview Prep (All-in-One)
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1176,22 +1176,22 @@
                   </span>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >Online courses</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >Online courses</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         Resume + Interview Prep (All-in-One)
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1255,22 +1255,22 @@
                   </div>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >E-books</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >E-books</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         Branding & Networking for Marketers
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1323,22 +1323,22 @@
                   </span>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >Online courses</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >Online courses</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         Resume + Interview Prep (All-in-One)
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"
@@ -1387,7 +1387,7 @@
                     >
                   </button>
                   <div
-                    class="absolute inset-0 p-5 flex flex-col justify-between text-white"
+                    class="absolute inset-0 p-5 flex flex-col justify-start gap-3 text-white"
                   >
                     <div>
                       <span
@@ -1412,28 +1412,28 @@
                   </div>
                 </div>
                 <div class="p-5">
-                  <div class="flex justify-between items-start gap-3 mb-2">
-                    <div class="flex flex-col gap-1">
-                      <div class="flex items-center gap-2">
-                        <span class="text-[10px] font-semibold text-gray-400"
-                          >2025.05.10</span
-                        >
-                        <span class="text-[10px] font-semibold text-gray-400"
-                          >·</span
-                        >
-                        <span class="text-[10px] font-semibold text-[#FF6B3D]"
-                          >Workshops</span
-                        >
-                      </div>
+                  <div class="flex flex-col gap-1 mb-2">
+                    <div class="flex items-center gap-2">
+                      <span class="text-[10px] font-semibold text-gray-400"
+                        >2025.05.10</span
+                      >
+                      <span class="text-[10px] font-semibold text-gray-400"
+                        >·</span
+                      >
+                      <span class="text-[10px] font-semibold text-[#FF6B3D]"
+                        >Workshops</span
+                      >
+                    </div>
+                    <div class="flex justify-between items-start gap-3">
                       <h3
-                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2 mt-1"
+                        class="text-sm font-bold font-headline text-navy leading-tight line-clamp-2"
                       >
                         UX Design Fundamentals
                       </h3>
+                      <span class="text-base font-extrabold text-navy"
+                        >$2800</span
+                      >
                     </div>
-                    <span class="text-base font-extrabold text-navy"
-                      >$2800</span
-                    >
                   </div>
                   <p
                     class="text-xs text-body leading-relaxed line-clamp-3 mb-4"

--- a/public/html/workshops/workshop_detail.html
+++ b/public/html/workshops/workshop_detail.html
@@ -283,7 +283,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -1729,6 +1730,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/html/workshops/workshop_list.html
+++ b/public/html/workshops/workshop_list.html
@@ -246,7 +246,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -1615,6 +1616,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/public/main.html
+++ b/public/main.html
@@ -522,7 +522,8 @@
             padding-top 0.25s ease-out;
         }
         .mobile-nav-panel.is-open {
-          max-height: 42rem;
+          max-height: calc(100vh - 4rem);
+          overflow-y: auto;
           opacity: 1;
           padding-top: 12px;
           pointer-events: auto;
@@ -4276,6 +4277,21 @@
 
             toggle.addEventListener('click', function () {
               var isOpen = toggle.getAttribute('aria-expanded') === 'true';
+              if (!isOpen) {
+                Array.prototype.forEach.call(
+                  document.querySelectorAll('.mobile-nav-accordion-toggle'),
+                  function (otherToggle) {
+                    if (otherToggle !== toggle) {
+                      otherToggle.setAttribute('aria-expanded', 'false');
+                      var otherPanelId = otherToggle.getAttribute('data-target');
+                      var otherPanel = otherPanelId ? document.getElementById(otherPanelId) : null;
+                      if (otherPanel) {
+                        otherPanel.classList.remove('is-open');
+                      }
+                    }
+                  }
+                );
+              }
               toggle.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
               panel.classList.toggle('is-open', !isOpen);
             });

--- a/src/app/admin/admin-actions-auth.test.ts
+++ b/src/app/admin/admin-actions-auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireAdminUser: vi.fn()
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireAdminUser: mocks.requireAdminUser
+}));
+
+vi.mock('@/lib/prisma', () => ({ default: {} }));
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+
+import { getUsers } from './users/actions';
+import { getEbooks } from '@/components/admin/ebooks/actions/ebook-actions';
+
+describe('admin server actions', () => {
+  it.each([
+    [{ ok: false, status: 401, error: 'Unauthorized' }],
+    [{ ok: false, status: 403, error: 'Forbidden' }]
+  ])('rejects admin actions without access: %o', async (adminAccess) => {
+    mocks.requireAdminUser.mockResolvedValue(adminAccess);
+
+    await expect(getUsers()).rejects.toThrow(adminAccess.error);
+    await expect(getEbooks()).rejects.toThrow(adminAccess.error);
+  });
+});

--- a/src/app/admin/admin-client-layout.tsx
+++ b/src/app/admin/admin-client-layout.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { UserProvider } from '../context/user-context';
+import AdminPage from '@/components/admin/layout/admin-page';
+import { AdminHeader } from '@/components/admin/layout/admin-header';
+import { AdminFooter } from '@/components/admin/layout/admin-footer';
+import { NavigationBlockerProvider } from '@/components/admin/common/navigation-blocker-context';
+
+export default function AdminClientLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <UserProvider>
+      <NavigationBlockerProvider>
+        <div className="flex h-screen flex-col">
+          <AdminHeader />
+          <div className="flex flex-1">
+            <AdminPage>{children}</AdminPage>
+          </div>
+          <AdminFooter />
+        </div>
+      </NavigationBlockerProvider>
+    </UserProvider>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,32 +1,17 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { requireAdminUser } from '@/lib/admin-auth';
+import AdminClientLayout from './admin-client-layout';
 
-import '@/app/globals.css';
-import { UserProvider } from '../context/user-context';
-import AdminPage from '@/components/admin/layout/admin-page';
-import { AdminHeader } from '@/components/admin/layout/admin-header';
-import { AdminFooter } from '@/components/admin/layout/admin-footer';
-import { NavigationBlockerProvider } from '@/components/admin/common/navigation-blocker-context';
-
-export default function AdminLayout({
+export default async function AdminLayout({
   children
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <UserProvider>
-      <NavigationBlockerProvider>
-        <div className="flex h-screen flex-col">
-          {/* 어드민 전용 헤더 */}
-          <AdminHeader />
+  const adminAccess = await requireAdminUser();
 
-          {/* 본문 (사이드바 + 컨텐츠) */}
-          <div className="flex flex-1">
-            <AdminPage>{children}</AdminPage>
-          </div>
+  if (!adminAccess.ok) {
+    redirect(adminAccess.status === 401 ? '/sign-in?redirect_url=/admin' : '/');
+  }
 
-          <AdminFooter />
-        </div>
-      </NavigationBlockerProvider>
-    </UserProvider>
-  );
+  return <AdminClientLayout>{children}</AdminClientLayout>;
 }

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -2,12 +2,21 @@
 
 import prisma from '@/lib/prisma';
 import { UserRow, UserRole } from '@/types/admin/user';
+import { requireAdminUser } from '@/lib/admin-auth';
+
+async function requireAdminAction() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    throw new Error(adminAccess.error);
+  }
+}
 
 export async function getUsers(
   page: number = 1,
   limit: number = 10,
   roleFilter: 'all' | UserRole = 'all'
 ): Promise<{ users: UserRow[]; total: number }> {
+  await requireAdminAction();
   const skip = (page - 1) * limit;
 
   // Build where clause based on role filter
@@ -95,6 +104,7 @@ export interface OrderDetail {
 }
 
 export async function getUserOrders(userId: string): Promise<OrderDetail[]> {
+  await requireAdminAction();
   const orders = await prisma.order.findMany({
     where: {
       userId: userId

--- a/src/app/api/document/route.ts
+++ b/src/app/api/document/route.ts
@@ -4,9 +4,18 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { format } from 'date-fns';
 import prisma from '@/lib/prisma';
 import { bucketName, s3clientSupabase } from '@/lib/supabase';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all documents
 export async function GET() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const ebooks = await prisma.ebook.findMany();
     return NextResponse.json(ebooks, { status: 200 });
@@ -20,6 +29,14 @@ export async function GET() {
 
 // Upload new document
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const file = formData.get('document') as File;

--- a/src/app/api/ebooks/reorder/route.ts
+++ b/src/app/api/ebooks/reorder/route.ts
@@ -2,8 +2,17 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderKey: string }[] };

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -3,8 +3,17 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { v4 as uuidv4 } from 'uuid';
 import prisma from '@/lib/prisma';
 import { bucketName, s3clientSupabase } from '@/lib/supabase';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const file = (formData.get('image') || formData.get('file')) as File | null;

--- a/src/app/api/main-visual/[id]/route.ts
+++ b/src/app/api/main-visual/[id]/route.ts
@@ -4,6 +4,7 @@ import { imgBucketName, s3clientSupabase } from '@/lib/supabase';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { format } from 'date-fns';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function GET(
   req: Request,
@@ -35,6 +36,14 @@ export async function PUT(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     const formData = await req.formData();
@@ -114,6 +123,14 @@ export async function DELETE(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     await prisma.mainVisual.delete({

--- a/src/app/api/main-visual/[id]/status/route.ts
+++ b/src/app/api/main-visual/[id]/status/route.ts
@@ -1,11 +1,20 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     const { isPublic } = await req.json();

--- a/src/app/api/main-visual/reorder/route.ts
+++ b/src/app/api/main-visual/reorder/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderIndex: number }[] };

--- a/src/app/api/main-visual/route.ts
+++ b/src/app/api/main-visual/route.ts
@@ -4,6 +4,7 @@ import { imgBucketName, s3clientSupabase } from '@/lib/supabase';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { format } from 'date-fns';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all main visuals
 export async function GET() {
@@ -23,6 +24,14 @@ export async function GET() {
 // Create new document or mark existing?
 // For this admin, we create a specialized Main Visual Document.
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const title = formData.get('title') as string;

--- a/src/app/api/videos/route.ts
+++ b/src/app/api/videos/route.ts
@@ -1,8 +1,17 @@
 import prisma from '@/lib/prisma';
 import { NextResponse } from 'next/server';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all videos
 export async function GET() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const videos = await prisma.video.findMany();
     return NextResponse.json(videos, { status: 200 });
@@ -16,6 +25,14 @@ export async function GET() {
 
 // Create new video
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { videoId, title, description, price, courseId } = body;

--- a/src/app/api/workshops/[workshopId]/route.ts
+++ b/src/app/api/workshops/[workshopId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { WorkshopStatus, WorkshopCategory } from '@prisma/client';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 const RECRUIT_STATUS_MAP: Record<string, string> = {
   모집중: 'OPEN',
@@ -32,6 +33,14 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ workshopId: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   const { workshopId } = await params;
 
   try {

--- a/src/app/api/workshops/reorder/route.ts
+++ b/src/app/api/workshops/reorder/route.ts
@@ -2,8 +2,17 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderKey: string }[] };

--- a/src/app/api/workshops/route.ts
+++ b/src/app/api/workshops/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { WorkshopStatus, WorkshopCategory } from '@prisma/client';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 const RECRUIT_STATUS_MAP: Record<string, string> = {
   모집중: 'OPEN',
@@ -197,6 +198,14 @@ export async function GET(req: Request) {
 }
 
 export async function POST(request: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await request.json();
     const {
@@ -286,6 +295,14 @@ export async function POST(request: Request) {
 }
 
 export async function DELETE(request: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { ids } = await request.json();
 

--- a/src/app/context/purchase-context.test.tsx
+++ b/src/app/context/purchase-context.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PurchaseProvider, usePurchase } from '@/app/context/purchase-context';
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  useAuth: vi.fn()
+}));
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: mocks.useAuth
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError
+  }
+}));
+
+function PurchaseStatusActions() {
+  const { checkPurchaseStatus, isPurchased } = usePurchase();
+
+  return (
+    <>
+      <output data-testid="purchase-status">{String(isPurchased)}</output>
+      <button onClick={() => checkPurchaseStatus('video123')}>
+        Check video
+      </button>
+      <button onClick={() => checkPurchaseStatus('invalid-video')}>
+        Check invalid video
+      </button>
+    </>
+  );
+}
+
+describe('PurchaseProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({
+      userId: 'user_123',
+      isLoaded: true
+    });
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('does not fetch purchase status just because the provider mounts', () => {
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('checks the explicitly requested valid video ID', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: vi.fn().mockResolvedValue({ purchasedVideoIds: ['video123'] })
+    } as unknown as Response);
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/purchase-video-status?clerkId=user_123'
+      );
+      expect(screen.getByTestId('purchase-status')).toHaveTextContent('true');
+    });
+  });
+
+  it('does not fetch when a valid video ID is requested before authentication is available', () => {
+    mocks.useAuth.mockReturnValue({
+      userId: null,
+      isLoaded: false
+    });
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId('purchase-status')).toHaveTextContent('false');
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicitly requested invalid video ID without fetching', () => {
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Check invalid video' })
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith('Invalid video ID format');
+  });
+
+  it('reports a failed explicit purchase status check', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('network down'));
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        'Purchase check failed: network down'
+      );
+    });
+    expect(screen.getByTestId('purchase-status')).toHaveTextContent('false');
+  });
+});

--- a/src/app/context/purchase-context.tsx
+++ b/src/app/context/purchase-context.tsx
@@ -1,13 +1,6 @@
 'use client';
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useCallback
-} from 'react';
+import { createContext, useContext, useState, useCallback } from 'react';
 import { useAuth } from '@clerk/nextjs';
-import { usePathname } from 'next/navigation';
 import { toast } from 'sonner';
 
 type PurchaseContextType = {
@@ -20,9 +13,7 @@ const PurchaseContext = createContext<PurchaseContextType | null>(null);
 
 export function PurchaseProvider({ children }: { children: React.ReactNode }) {
   const { userId, isLoaded } = useAuth();
-  const pathname = usePathname();
   const [isPurchased, setIsPurchased] = useState(false);
-  const [currentVideoId, setCurrentVideoId] = useState<string | null>(null);
 
   const checkPurchaseStatus = useCallback(
     async (videoId: string | undefined) => {
@@ -33,7 +24,6 @@ export function PurchaseProvider({ children }: { children: React.ReactNode }) {
         toast.error('Invalid video ID format');
         return;
       }
-      setCurrentVideoId(videoId);
 
       if (!userId || !videoId || !isLoaded) {
         return;
@@ -56,25 +46,6 @@ export function PurchaseProvider({ children }: { children: React.ReactNode }) {
     },
     [userId, isLoaded, setIsPurchased]
   );
-
-  // Effect to get videoId from URL
-  useEffect(() => {
-    const videoIdFromPath = pathname?.split('/')?.[1];
-    if (videoIdFromPath && videoIdFromPath !== currentVideoId) {
-      checkPurchaseStatus(videoIdFromPath);
-    }
-  }, [pathname, checkPurchaseStatus, currentVideoId]);
-
-  // Effect to handle auth state changes and page refreshes
-  useEffect(() => {
-    if (isLoaded) {
-      if (!userId) {
-        setIsPurchased(false);
-      } else if (currentVideoId) {
-        checkPurchaseStatus(currentVideoId);
-      }
-    }
-  }, [userId, isLoaded, currentVideoId, checkPurchaseStatus]);
 
   return (
     <PurchaseContext.Provider

--- a/src/components/admin/ebooks/actions/ebook-actions.ts
+++ b/src/components/admin/ebooks/actions/ebook-actions.ts
@@ -5,6 +5,14 @@ import { EbookCategory, TargetAudienceType } from '@prisma/client';
 import { generateKeyBetween } from 'fractional-indexing';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
+import { requireAdminUser } from '@/lib/admin-auth';
+
+async function requireAdminAction() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    throw new Error(adminAccess.error);
+  }
+}
 
 export type EbookData = {
   id?: string;
@@ -32,6 +40,7 @@ export type EbookData = {
 };
 
 export async function createEbook(data: EbookData) {
+  await requireAdminAction();
   try {
     const {
       category,
@@ -90,6 +99,7 @@ export async function createEbook(data: EbookData) {
 }
 
 export async function updateEbook(id: string, data: EbookData) {
+  await requireAdminAction();
   try {
     const {
       category,
@@ -142,6 +152,7 @@ export async function updateEbook(id: string, data: EbookData) {
 }
 
 export async function getEbooks(page = 1, limit = 10) {
+  await requireAdminAction();
   const skip = (page - 1) * limit;
   const total = await prisma.ebook.count();
 
@@ -212,6 +223,7 @@ export type EbookWithStats = Awaited<
 >['items'][number];
 
 export async function getEbook(id: string) {
+  await requireAdminAction();
   const ebook = await prisma.ebook.findUnique({
     where: { id }
   });
@@ -219,6 +231,7 @@ export async function getEbook(id: string) {
 }
 
 export async function deleteEbook(id: string) {
+  await requireAdminAction();
   try {
     await prisma.ebook.delete({
       where: { id }
@@ -232,6 +245,7 @@ export async function deleteEbook(id: string) {
 export async function updateEbookStatuses(
   updates: { id: string; isPublic: boolean }[]
 ) {
+  await requireAdminAction();
   try {
     await prisma.$transaction(
       updates.map(({ id, isPublic }) =>


### PR DESCRIPTION
## Why this PR:

The root-level PurchaseProvider treated the first segment of every pathname as a video ID. As a result, non-video routes such as `/sso-callback` could show an `Invalid video ID format` toast, while routes such as `/courses/:id` and `/ebooks/:id` could make an unnecessary purchase-status request.

## Changes:

- Remove pathname-based purchase-status checks from the globally mounted PurchaseProvider.
- Keep `checkPurchaseStatus(videoId)` available for flows that explicitly request a video purchase-status check.
- Preserve invalid-ID validation and purchase-status error handling for explicit calls.
- Add coverage for initial provider mount, explicit valid and invalid video IDs, unavailable authentication, and request failures.

## How to Test:

### Automated

1. Run `npm test -- --run src/app/context/purchase-context.test.tsx`.
2. Run `npm test -- --run`.
3. Run `npm run typecheck`, `npm run build`, and `npm run lint`.

### Manual

1. Start the app with `npm run dev`. Complete the Google sign-in flow from `/sign-in` and confirm the app returns to `/`. Do not open `/sso-callback` directly; it is an OAuth callback route and requires callback state.
2. Visit non-video routes such as `/sign-in`, `/sign-up`, `/courses/{courseId}`, and `/ebooks/{ebookId}`. Confirm no `Invalid video ID format` toast appears and no `/api/purchase-video-status` request is made solely from pathname navigation.
3. The explicit `checkPurchaseStatus` success, invalid-ID, unavailable-authentication, and request-failure cases are covered by `src/app/context/purchase-context.test.tsx`; there is currently no production UI flow that calls this method directly.