### PR TITLE
PACE-243 Protect admin routes and actions

### DIFF
--- a/src/app/admin/admin-actions-auth.test.ts
+++ b/src/app/admin/admin-actions-auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  requireAdminUser: vi.fn()
+}));
+
+vi.mock('@/lib/admin-auth', () => ({
+  requireAdminUser: mocks.requireAdminUser
+}));
+
+vi.mock('@/lib/prisma', () => ({ default: {} }));
+vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
+
+import { getUsers } from './users/actions';
+import { getEbooks } from '@/components/admin/ebooks/actions/ebook-actions';
+
+describe('admin server actions', () => {
+  it.each([
+    [{ ok: false, status: 401, error: 'Unauthorized' }],
+    [{ ok: false, status: 403, error: 'Forbidden' }]
+  ])('rejects admin actions without access: %o', async (adminAccess) => {
+    mocks.requireAdminUser.mockResolvedValue(adminAccess);
+
+    await expect(getUsers()).rejects.toThrow(adminAccess.error);
+    await expect(getEbooks()).rejects.toThrow(adminAccess.error);
+  });
+});

--- a/src/app/admin/admin-client-layout.tsx
+++ b/src/app/admin/admin-client-layout.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { UserProvider } from '../context/user-context';
+import AdminPage from '@/components/admin/layout/admin-page';
+import { AdminHeader } from '@/components/admin/layout/admin-header';
+import { AdminFooter } from '@/components/admin/layout/admin-footer';
+import { NavigationBlockerProvider } from '@/components/admin/common/navigation-blocker-context';
+
+export default function AdminClientLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <UserProvider>
+      <NavigationBlockerProvider>
+        <div className="flex h-screen flex-col">
+          <AdminHeader />
+          <div className="flex flex-1">
+            <AdminPage>{children}</AdminPage>
+          </div>
+          <AdminFooter />
+        </div>
+      </NavigationBlockerProvider>
+    </UserProvider>
+  );
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,32 +1,17 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { requireAdminUser } from '@/lib/admin-auth';
+import AdminClientLayout from './admin-client-layout';
 
-import '@/app/globals.css';
-import { UserProvider } from '../context/user-context';
-import AdminPage from '@/components/admin/layout/admin-page';
-import { AdminHeader } from '@/components/admin/layout/admin-header';
-import { AdminFooter } from '@/components/admin/layout/admin-footer';
-import { NavigationBlockerProvider } from '@/components/admin/common/navigation-blocker-context';
-
-export default function AdminLayout({
+export default async function AdminLayout({
   children
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <UserProvider>
-      <NavigationBlockerProvider>
-        <div className="flex h-screen flex-col">
-          {/* 어드민 전용 헤더 */}
-          <AdminHeader />
+  const adminAccess = await requireAdminUser();
 
-          {/* 본문 (사이드바 + 컨텐츠) */}
-          <div className="flex flex-1">
-            <AdminPage>{children}</AdminPage>
-          </div>
+  if (!adminAccess.ok) {
+    redirect(adminAccess.status === 401 ? '/sign-in?redirect_url=/admin' : '/');
+  }
 
-          <AdminFooter />
-        </div>
-      </NavigationBlockerProvider>
-    </UserProvider>
-  );
+  return <AdminClientLayout>{children}</AdminClientLayout>;
 }

--- a/src/app/admin/users/actions.ts
+++ b/src/app/admin/users/actions.ts
@@ -2,12 +2,21 @@
 
 import prisma from '@/lib/prisma';
 import { UserRow, UserRole } from '@/types/admin/user';
+import { requireAdminUser } from '@/lib/admin-auth';
+
+async function requireAdminAction() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    throw new Error(adminAccess.error);
+  }
+}
 
 export async function getUsers(
   page: number = 1,
   limit: number = 10,
   roleFilter: 'all' | UserRole = 'all'
 ): Promise<{ users: UserRow[]; total: number }> {
+  await requireAdminAction();
   const skip = (page - 1) * limit;
 
   // Build where clause based on role filter
@@ -95,6 +104,7 @@ export interface OrderDetail {
 }
 
 export async function getUserOrders(userId: string): Promise<OrderDetail[]> {
+  await requireAdminAction();
   const orders = await prisma.order.findMany({
     where: {
       userId: userId

--- a/src/app/api/document/route.ts
+++ b/src/app/api/document/route.ts
@@ -4,9 +4,18 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { format } from 'date-fns';
 import prisma from '@/lib/prisma';
 import { bucketName, s3clientSupabase } from '@/lib/supabase';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all documents
 export async function GET() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const ebooks = await prisma.ebook.findMany();
     return NextResponse.json(ebooks, { status: 200 });
@@ -20,6 +29,14 @@ export async function GET() {
 
 // Upload new document
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const file = formData.get('document') as File;

--- a/src/app/api/ebooks/reorder/route.ts
+++ b/src/app/api/ebooks/reorder/route.ts
@@ -2,8 +2,17 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderKey: string }[] };

--- a/src/app/api/images/upload/route.ts
+++ b/src/app/api/images/upload/route.ts
@@ -3,8 +3,17 @@ import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { v4 as uuidv4 } from 'uuid';
 import prisma from '@/lib/prisma';
 import { bucketName, s3clientSupabase } from '@/lib/supabase';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const file = (formData.get('image') || formData.get('file')) as File | null;

--- a/src/app/api/main-visual/[id]/route.ts
+++ b/src/app/api/main-visual/[id]/route.ts
@@ -4,6 +4,7 @@ import { imgBucketName, s3clientSupabase } from '@/lib/supabase';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { format } from 'date-fns';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function GET(
   req: Request,
@@ -35,6 +36,14 @@ export async function PUT(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     const formData = await req.formData();
@@ -114,6 +123,14 @@ export async function DELETE(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     await prisma.mainVisual.delete({

--- a/src/app/api/main-visual/[id]/status/route.ts
+++ b/src/app/api/main-visual/[id]/status/route.ts
@@ -1,11 +1,20 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(
   req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { id } = await params;
     const { isPublic } = await req.json();

--- a/src/app/api/main-visual/reorder/route.ts
+++ b/src/app/api/main-visual/reorder/route.ts
@@ -1,8 +1,17 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderIndex: number }[] };

--- a/src/app/api/main-visual/route.ts
+++ b/src/app/api/main-visual/route.ts
@@ -4,6 +4,7 @@ import { imgBucketName, s3clientSupabase } from '@/lib/supabase';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { format } from 'date-fns';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all main visuals
 export async function GET() {
@@ -23,6 +24,14 @@ export async function GET() {
 // Create new document or mark existing?
 // For this admin, we create a specialized Main Visual Document.
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const formData = await req.formData();
     const title = formData.get('title') as string;

--- a/src/app/api/videos/route.ts
+++ b/src/app/api/videos/route.ts
@@ -1,8 +1,17 @@
 import prisma from '@/lib/prisma';
 import { NextResponse } from 'next/server';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 // Get all videos
 export async function GET() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const videos = await prisma.video.findMany();
     return NextResponse.json(videos, { status: 200 });
@@ -16,6 +25,14 @@ export async function GET() {
 
 // Create new video
 export async function POST(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { videoId, title, description, price, courseId } = body;

--- a/src/app/api/workshops/[workshopId]/route.ts
+++ b/src/app/api/workshops/[workshopId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { WorkshopStatus, WorkshopCategory } from '@prisma/client';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 const RECRUIT_STATUS_MAP: Record<string, string> = {
   모집중: 'OPEN',
@@ -32,6 +33,14 @@ export async function PUT(
   request: Request,
   { params }: { params: Promise<{ workshopId: string }> }
 ) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   const { workshopId } = await params;
 
   try {

--- a/src/app/api/workshops/reorder/route.ts
+++ b/src/app/api/workshops/reorder/route.ts
@@ -2,8 +2,17 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 export async function PATCH(req: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await req.json();
     const { items } = body as { items: { id: string; orderKey: string }[] };

--- a/src/app/api/workshops/route.ts
+++ b/src/app/api/workshops/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import { WorkshopStatus, WorkshopCategory } from '@prisma/client';
+import { requireAdminUser } from '@/lib/admin-auth';
 
 const RECRUIT_STATUS_MAP: Record<string, string> = {
   모집중: 'OPEN',
@@ -197,6 +198,14 @@ export async function GET(req: Request) {
 }
 
 export async function POST(request: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const body = await request.json();
     const {
@@ -286,6 +295,14 @@ export async function POST(request: Request) {
 }
 
 export async function DELETE(request: Request) {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    return NextResponse.json(
+      { error: adminAccess.error },
+      { status: adminAccess.status }
+    );
+  }
+
   try {
     const { ids } = await request.json();
 

--- a/src/app/context/purchase-context.test.tsx
+++ b/src/app/context/purchase-context.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PurchaseProvider, usePurchase } from '@/app/context/purchase-context';
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  useAuth: vi.fn()
+}));
+
+vi.mock('@clerk/nextjs', () => ({
+  useAuth: mocks.useAuth
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError
+  }
+}));
+
+function PurchaseStatusActions() {
+  const { checkPurchaseStatus, isPurchased } = usePurchase();
+
+  return (
+    <>
+      <output data-testid="purchase-status">{String(isPurchased)}</output>
+      <button onClick={() => checkPurchaseStatus('video123')}>
+        Check video
+      </button>
+      <button onClick={() => checkPurchaseStatus('invalid-video')}>
+        Check invalid video
+      </button>
+    </>
+  );
+}
+
+describe('PurchaseProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.useAuth.mockReturnValue({
+      userId: 'user_123',
+      isLoaded: true
+    });
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('does not fetch purchase status just because the provider mounts', () => {
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('checks the explicitly requested valid video ID', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      json: vi.fn().mockResolvedValue({ purchasedVideoIds: ['video123'] })
+    } as unknown as Response);
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/purchase-video-status?clerkId=user_123'
+      );
+      expect(screen.getByTestId('purchase-status')).toHaveTextContent('true');
+    });
+  });
+
+  it('does not fetch when a valid video ID is requested before authentication is available', () => {
+    mocks.useAuth.mockReturnValue({
+      userId: null,
+      isLoaded: false
+    });
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId('purchase-status')).toHaveTextContent('false');
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicitly requested invalid video ID without fetching', () => {
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Check invalid video' })
+    );
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith('Invalid video ID format');
+  });
+
+  it('reports a failed explicit purchase status check', async () => {
+    vi.mocked(fetch).mockRejectedValueOnce(new Error('network down'));
+
+    render(
+      <PurchaseProvider>
+        <PurchaseStatusActions />
+      </PurchaseProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Check video' }));
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        'Purchase check failed: network down'
+      );
+    });
+    expect(screen.getByTestId('purchase-status')).toHaveTextContent('false');
+  });
+});

--- a/src/app/context/purchase-context.tsx
+++ b/src/app/context/purchase-context.tsx
@@ -1,13 +1,6 @@
 'use client';
-import {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  useCallback
-} from 'react';
+import { createContext, useContext, useState, useCallback } from 'react';
 import { useAuth } from '@clerk/nextjs';
-import { usePathname } from 'next/navigation';
 import { toast } from 'sonner';
 
 type PurchaseContextType = {
@@ -20,9 +13,7 @@ const PurchaseContext = createContext<PurchaseContextType | null>(null);
 
 export function PurchaseProvider({ children }: { children: React.ReactNode }) {
   const { userId, isLoaded } = useAuth();
-  const pathname = usePathname();
   const [isPurchased, setIsPurchased] = useState(false);
-  const [currentVideoId, setCurrentVideoId] = useState<string | null>(null);
 
   const checkPurchaseStatus = useCallback(
     async (videoId: string | undefined) => {
@@ -33,7 +24,6 @@ export function PurchaseProvider({ children }: { children: React.ReactNode }) {
         toast.error('Invalid video ID format');
         return;
       }
-      setCurrentVideoId(videoId);
 
       if (!userId || !videoId || !isLoaded) {
         return;
@@ -56,25 +46,6 @@ export function PurchaseProvider({ children }: { children: React.ReactNode }) {
     },
     [userId, isLoaded, setIsPurchased]
   );
-
-  // Effect to get videoId from URL
-  useEffect(() => {
-    const videoIdFromPath = pathname?.split('/')?.[1];
-    if (videoIdFromPath && videoIdFromPath !== currentVideoId) {
-      checkPurchaseStatus(videoIdFromPath);
-    }
-  }, [pathname, checkPurchaseStatus, currentVideoId]);
-
-  // Effect to handle auth state changes and page refreshes
-  useEffect(() => {
-    if (isLoaded) {
-      if (!userId) {
-        setIsPurchased(false);
-      } else if (currentVideoId) {
-        checkPurchaseStatus(currentVideoId);
-      }
-    }
-  }, [userId, isLoaded, currentVideoId, checkPurchaseStatus]);
 
   return (
     <PurchaseContext.Provider

--- a/src/components/admin/ebooks/actions/ebook-actions.ts
+++ b/src/components/admin/ebooks/actions/ebook-actions.ts
@@ -5,6 +5,14 @@ import { EbookCategory, TargetAudienceType } from '@prisma/client';
 import { generateKeyBetween } from 'fractional-indexing';
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
+import { requireAdminUser } from '@/lib/admin-auth';
+
+async function requireAdminAction() {
+  const adminAccess = await requireAdminUser();
+  if (!adminAccess.ok) {
+    throw new Error(adminAccess.error);
+  }
+}
 
 export type EbookData = {
   id?: string;
@@ -32,6 +40,7 @@ export type EbookData = {
 };
 
 export async function createEbook(data: EbookData) {
+  await requireAdminAction();
   try {
     const {
       category,
@@ -90,6 +99,7 @@ export async function createEbook(data: EbookData) {
 }
 
 export async function updateEbook(id: string, data: EbookData) {
+  await requireAdminAction();
   try {
     const {
       category,
@@ -142,6 +152,7 @@ export async function updateEbook(id: string, data: EbookData) {
 }
 
 export async function getEbooks(page = 1, limit = 10) {
+  await requireAdminAction();
   const skip = (page - 1) * limit;
   const total = await prisma.ebook.count();
 
@@ -212,6 +223,7 @@ export type EbookWithStats = Awaited<
 >['items'][number];
 
 export async function getEbook(id: string) {
+  await requireAdminAction();
   const ebook = await prisma.ebook.findUnique({
     where: { id }
   });
@@ -219,6 +231,7 @@ export async function getEbook(id: string) {
 }
 
 export async function deleteEbook(id: string) {
+  await requireAdminAction();
   try {
     await prisma.ebook.delete({
       where: { id }
@@ -232,6 +245,7 @@ export async function deleteEbook(id: string) {
 export async function updateEbookStatuses(
   updates: { id: string; isPublic: boolean }[]
 ) {
+  await requireAdminAction();
   try {
     await prisma.$transaction(
       updates.map(({ id, isPublic }) =>


### PR DESCRIPTION
## Why this PR:

The `/admin` route tree had no server-side role protection, and several administrator-only API handlers and server actions could be invoked without verifying the signed-in user role. A non-admin user could reach administrative UI routes or call content-management operations directly.

## Changes:

- Add a server-side admin guard to the `/admin` layout using the existing Clerk-to-database role check.
- Redirect unauthenticated users to sign-in and non-admin users to the home page before rendering admin UI.
- Keep the existing client-only admin providers and layout UI in a dedicated client wrapper.
- Require admin access for image uploads, main visual mutations, workshop mutations, ebook reordering, video management, and document management APIs.
- Require admin access for ebook and user-management server actions.
- Add regression coverage for unauthenticated and non-admin server-action calls.

## How to Test:

### Automated

1. Run `npm test -- --run src/app/admin/admin-actions-auth.test.ts`.
2. Run `npm test -- --run`.
3. Run `npm run typecheck`, `npm run build`, and `npm run lint`.

### Manual

1. Start the app with `npm run dev` and open `/admin` in a signed-out browser session.
2. Confirm the app redirects to `/sign-in?redirect_url=/admin`.
3. Sign in as a non-admin user and open `/admin`. Confirm the app redirects to the home page.
4. Sign in as an ADMIN user and open `/admin`. Confirm the existing admin dashboard and content-management pages render normally.
5. While signed out or signed in as a non-admin, call an admin mutation such as `POST /api/images/upload` or `PATCH /api/main-visual/reorder`. Confirm the API returns `401` or `403` before processing request data.
6. Repeat the same admin mutation as an ADMIN user and confirm the existing operation succeeds without changing unrelated content.