### PR TITLE
fix(deps): align pdfjs-dist with react-pdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "lucide-react": "^1.27.0",
         "next": "15.5.21",
         "next-themes": "^0.4.6",
-        "pdfjs-dist": "5.7.284",
+        "pdfjs-dist": "5.4.296",
         "pg": "^8.22.0",
         "react": "^18",
         "react-big-calendar": "^1.20.0",
@@ -12495,15 +12495,15 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
+      "version": "5.4.296",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
+      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=22.13.0 || >=24"
+        "node": ">=20.16.0 || >=22.3.0"
       },
       "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
+        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/perfect-debounce": {
@@ -13336,18 +13336,6 @@
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-pdf/node_modules/pdfjs-dist": {
-      "version": "5.4.296",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.296.tgz",
-      "integrity": "sha512-DlOzet0HO7OEnmUmB6wWGJrrdvbyJKftI1bhMitK7O2N8W2gc757yyYBbINy9IDafXAV9wmKr9t7xsTaNKRG5Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20.16.0 || >=22.3.0"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.80"
       }
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "lucide-react": "^1.27.0",
     "next": "15.5.21",
     "next-themes": "^0.4.6",
-    "pdfjs-dist": "5.7.284",
+    "pdfjs-dist": "5.4.296",
     "pg": "^8.22.0",
     "react": "^18",
     "react-big-calendar": "^1.20.0",


### PR DESCRIPTION
## Summary

- pin direct `pdfjs-dist` to `5.4.296`, matching the exact version used by `react-pdf@10.4.1`
- deduplicate the PDF.js API and worker dependency to a single installed version
- remove vulnerable `pdfjs-dist@5.7.284` without introducing the PDF.js 6 major-version mismatch from #1071

This addresses Dependabot alert #198 for CVE-2026-16633. The affected range starts at 5.6.83, so the aligned 5.4.296 version is outside that advisory range.

## Validation

- `npm ls pdfjs-dist --all`: one deduplicated `5.4.296` installation
- `npm audit`: no `pdfjs-dist` finding
- `npm test -- --run`: 217 passed, 4 skipped
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- Aside signed-in smoke test: e-book list and detail loaded with no console or page errors

Note: `PdfViewer` is not currently imported by an application route, so there is no reachable PDF canvas flow for browser E2E.