### PR TITLE
fix(deps): patch PostCSS without upgrading Next.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^17.2.0",
-        "postcss": "^8",
+        "postcss": "8.5.23",
         "prettier": "^3.9.4",
         "prisma": "^7.8.0",
         "storybook": "^9.1.19",
@@ -12013,34 +12013,6 @@
         "tslib": "^2.8.0"
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/next/node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -12673,10 +12645,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
-      "dev": true,
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -12693,7 +12664,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^17.2.0",
-    "postcss": "^8",
+    "postcss": "8.5.23",
     "prettier": "^3.9.4",
     "prisma": "^7.8.0",
     "storybook": "^9.1.19",
@@ -114,7 +114,8 @@
     "@hono/node-server": "1.19.14",
     "@prisma/dev": "0.24.3",
     "effect": "^3.21.0",
-    "node-polyfill-webpack-plugin": "^4.1.0"
+    "node-polyfill-webpack-plugin": "^4.1.0",
+    "postcss": "$postcss"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
## Summary

- pin direct `postcss` to the patched `8.5.23` release
- add an npm override so Next.js and all transitive consumers use the same patched PostCSS version
- keep Next.js on 15.5.21, separating the security fix from the breaking Next.js 16 migration in #1075

This addresses the open PostCSS Dependabot alerts without coupling the fix to a framework major upgrade.

## Validation

- `npm ls postcss --all`: every consumer resolves to `8.5.23`
- `npm audit`: no `postcss` finding
- `npm test -- --run`: 217 passed, 4 skipped
- `npm run typecheck`
- `npm run build`
- `npm run lint`
- Aside signed-in smoke test: e-book list, styling, data load, and session UI verified with no console or page errors